### PR TITLE
Don't create containers with name during testing

### DIFF
--- a/5.5/test/run
+++ b/5.5/test/run
@@ -231,7 +231,7 @@ function test_config_option() {
   local option_value="$4"
 
   if ! echo "$configuration" | grep -qx "$option_name[[:space:]]*=[[:space:]]*$option_value"; then
-    local configs="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
+    local configs="$(docker exec -t "$(get_cid $container_name)" bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
     echo >&2 "FAIL: option '$option_name' should have value '$option_value', but it wasn't found in any of the configuration files ($configs):"
     echo >&2
     echo >&2 "$configuration"
@@ -249,7 +249,6 @@ function run_configuration_tests() {
 
   create_container \
     "$container_name" \
-    --name "$container_name" \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
     --env MYSQL_DATABASE=db \
@@ -275,7 +274,7 @@ function run_configuration_tests() {
   # - we should look for an option in the desired config, not in all of them
   # - we should respect section of the config (now we have duplicated options from a different sections)
   local configuration
-  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+  configuration="$(docker exec -t "$(get_cid $container_name)" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
 
   test_config_option "$container_name" "$configuration" lower_case_table_names 1
   test_config_option "$container_name" "$configuration" general_log 1
@@ -291,7 +290,7 @@ function run_configuration_tests() {
   test_config_option "$container_name" "$configuration" innodb_log_file_size 4M
   test_config_option "$container_name" "$configuration" innodb_log_buffer_size 4M
 
-  docker stop "$container_name" >/dev/null
+  docker stop "$(get_cid $container_name)" >/dev/null
 
   echo "  Success!"
   echo "  Testing image auto-calculated configuration settings"
@@ -300,14 +299,13 @@ function run_configuration_tests() {
 
   DOCKER_ARGS='--memory=256m' create_container \
     "$container_name" \
-    --name "$container_name" \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
     --env MYSQL_DATABASE=db
 
   test_connection "$container_name" config_test_user config_test
 
-  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+  configuration="$(docker exec -t "$(get_cid $container_name)" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
 
   test_config_option "$container_name" "$configuration" key_buffer_size 25M
   test_config_option "$container_name" "$configuration" read_buffer_size 12M
@@ -315,7 +313,7 @@ function run_configuration_tests() {
   test_config_option "$container_name" "$configuration" innodb_log_file_size 38M
   test_config_option "$container_name" "$configuration" innodb_log_buffer_size 38M
 
-  docker stop "$container_name" >/dev/null
+  docker stop "$(get_cid $container_name)" >/dev/null
 
   echo "  Success!"
 }

--- a/5.6/test/run
+++ b/5.6/test/run
@@ -231,7 +231,7 @@ function test_config_option() {
   local option_value="$4"
 
   if ! echo "$configuration" | grep -qx "$option_name[[:space:]]*=[[:space:]]*$option_value"; then
-    local configs="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
+    local configs="$(docker exec -t "$(get_cid $container_name)" bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
     echo >&2 "FAIL: option '$option_name' should have value '$option_value', but it wasn't found in any of the configuration files ($configs):"
     echo >&2
     echo >&2 "$configuration"
@@ -249,7 +249,6 @@ function run_configuration_tests() {
 
   create_container \
     "$container_name" \
-    --name "$container_name" \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
     --env MYSQL_DATABASE=db \
@@ -275,7 +274,7 @@ function run_configuration_tests() {
   # - we should look for an option in the desired config, not in all of them
   # - we should respect section of the config (now we have duplicated options from a different sections)
   local configuration
-  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+  configuration="$(docker exec -t "$(get_cid $container_name)" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
 
   test_config_option "$container_name" "$configuration" lower_case_table_names 1
   test_config_option "$container_name" "$configuration" general_log 1
@@ -291,7 +290,7 @@ function run_configuration_tests() {
   test_config_option "$container_name" "$configuration" innodb_log_file_size 4M
   test_config_option "$container_name" "$configuration" innodb_log_buffer_size 4M
 
-  docker stop "$container_name" >/dev/null
+  docker stop "$(get_cid $container_name)" >/dev/null
 
   echo "  Success!"
   echo "  Testing image auto-calculated configuration settings"
@@ -300,14 +299,13 @@ function run_configuration_tests() {
 
   DOCKER_ARGS='--memory=256m' create_container \
     "$container_name" \
-    --name "$container_name" \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
     --env MYSQL_DATABASE=db
 
   test_connection "$container_name" config_test_user config_test
 
-  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+  configuration="$(docker exec -t "$(get_cid $container_name)" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
 
   test_config_option "$container_name" "$configuration" key_buffer_size 25M
   test_config_option "$container_name" "$configuration" read_buffer_size 12M
@@ -315,7 +313,7 @@ function run_configuration_tests() {
   test_config_option "$container_name" "$configuration" innodb_log_file_size 38M
   test_config_option "$container_name" "$configuration" innodb_log_buffer_size 38M
 
-  docker stop "$container_name" >/dev/null
+  docker stop "$(get_cid $container_name)" >/dev/null
 
   echo "  Success!"
 }


### PR DESCRIPTION
mariadb-container and mysql-container contains almost same `test/run` script. So now it is not possible to run mariadb and mysql tests simultaneously (both creates containers `config_test` and `dynamic_config_test`).

This PR fixes this. So test script doesn't create containers with name and it address them by cidfile.

@hhorak @bparees @mnagy Please take a look.