### PR TITLE
Ignore lost+found directory that exists in mounted persistent volumes

### DIFF
--- a/5.7/root/usr/share/container-scripts/mysql/common.sh
+++ b/5.7/root/usr/share/container-scripts/mysql/common.sh
@@ -96,7 +96,7 @@ function initialize_database() {
     mysql_install_db --rpm --datadir=$MYSQL_DATADIR
   else
     log_info "Running mysqld --initialize-insecure ..."
-    ${MYSQL_PREFIX}/libexec/mysqld --initialize-insecure --datadir=$MYSQL_DATADIR
+    ${MYSQL_PREFIX}/libexec/mysqld --initialize-insecure --datadir=$MYSQL_DATADIR --ignore-db-dir=lost+found
   fi
   start_local_mysql "$@"
 


### PR DESCRIPTION
When using the MySQL 5.7 image with a PV in OpenShift, MySQL goes into
a crash loop with ‘[ERROR] --initialize specified but the data
directory exists. Aborting.’ Upon investigation, new PV’s have a
lost+found directory, which is permitted in MySQL 5.7.11+, so long as
—ignore-db-dir is set. The issue is described in the MySQL docs here:
https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir