### PR TITLE
Update Dockerfiles

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -24,7 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MySQL 5.6" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mysql56,rh-mysql56"
+      io.openshift.tags="database,mysql,mysql56,rh-mysql56" \
+      com.redhat.component="rh-mysql56-docker" \
+      name="centos/mysql-56-centos7" \
+      version="5.6" \
+      release="1"
 
 EXPOSE 3306
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -51,7 +51,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -60,7 +60,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -24,14 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MySQL 5.6" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mysql56,rh-mysql56"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-mysql56-docker" \
+      io.openshift.tags="database,mysql,mysql56,rh-mysql56" \
+      com.redhat.component="rh-mysql56-docker" \
       name="rhscl/mysql-56-rhel7" \
       version="5.6" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 EXPOSE 3306
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -24,7 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MySQL 5.7" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mysql57,rh-mysql57"
+      io.openshift.tags="database,mysql,mysql57,rh-mysql57" \
+      com.redhat.component="rh-mysql57-docker" \
+      name="centos/mysql-57-centos7" \
+      version="5.7" \
+      release="1"
 
 EXPOSE 3306
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -53,7 +53,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/5.7/Dockerfile.rhel7
+++ b/5.7/Dockerfile.rhel7
@@ -60,7 +60,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/5.7/Dockerfile.rhel7
+++ b/5.7/Dockerfile.rhel7
@@ -24,14 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MySQL 5.7" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mysql57,rh-mysql57"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-mysql57-docker" \
+      io.openshift.tags="database,mysql,mysql57,rh-mysql57" \
+      com.redhat.component="rh-mysql57-docker" \
       name="rhscl/mysql-57-rhel7" \
       version="5.7" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 EXPOSE 3306
 


### PR DESCRIPTION
Use COPY instruction instead of ADD
(COPY is preffered for simple usage - see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy)

Provide same labels for all base image variants (CentOS, RHEL, Fedora)
    - add name and version labels
    - remove architecture label for RHEL based images (this label is set in RHE$

(don't use separate instruction for each label)

@hhorak @praiskup @pkubatrh Please take a look and merge.