### PR TITLE
Do not set innodb_additional_mem_pool_size which is deprecated

### DIFF
--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -35,9 +35,14 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y yum-utils && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils && \
+    yum-config-manager --disable * &> /dev/null && \
+    yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS="rsync tar gettext hostname bind-utils rh-mysql56" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/5.6/root/usr/bin/run-mysqld
+++ b/5.6/root/usr/bin/run-mysqld
@@ -14,9 +14,6 @@ log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
-if [[ "$MYSQL_VERSION" < "5.7" ]] ; then
-  envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning-56-low.cnf.template > /etc/my.cnf.d/tuning-56-low.cnf
-fi
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.6/root/usr/bin/run-mysqld-master
+++ b/5.6/root/usr/bin/run-mysqld-master
@@ -24,9 +24,6 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.c
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-master.cnf.template > /etc/my.cnf.d/master.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-repl-gtid.cnf.template > /etc/my.cnf.d/repl-gtid.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
-if [[ "$MYSQL_VERSION" < "5.7" ]] ; then
-  envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning-56-low.cnf.template > /etc/my.cnf.d/tuning-56-low.cnf
-fi
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.6/root/usr/bin/run-mysqld-slave
+++ b/5.6/root/usr/bin/run-mysqld-slave
@@ -25,9 +25,6 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.c
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-slave.cnf.template > /etc/my.cnf.d/slave.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-repl-gtid.cnf.template > /etc/my.cnf.d/repl-gtid.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
-if [[ "$MYSQL_VERSION" < "5.7" ]] ; then
-  envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning-56-low.cnf.template > /etc/my.cnf.d/tuning-56-low.cnf
-fi
 
 if [ ! -e "${MYSQL_DATADIR}/mysql" ]; then
   # Initialize MySQL database and wait for the MySQL master to accept

--- a/5.6/root/usr/share/container-scripts/mysql/my-tuning-56-low.cnf.template
+++ b/5.6/root/usr/share/container-scripts/mysql/my-tuning-56-low.cnf.template
@@ -1,2 +1,0 @@
-[mysqld]
-innodb_additional_mem_pool_size = 2M

--- a/5.7/Dockerfile.rhel7
+++ b/5.7/Dockerfile.rhel7
@@ -35,9 +35,14 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y yum-utils && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils && \
+    yum-config-manager --disable * &> /dev/null && \
+    yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS="rsync tar gettext hostname bind-utils rh-mysql57" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/5.7/root/usr/bin/run-mysqld
+++ b/5.7/root/usr/bin/run-mysqld
@@ -14,9 +14,6 @@ log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
-if [[ "$MYSQL_VERSION" < "5.7" ]] ; then
-  envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning-56-low.cnf.template > /etc/my.cnf.d/tuning-56-low.cnf
-fi
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.7/root/usr/bin/run-mysqld-master
+++ b/5.7/root/usr/bin/run-mysqld-master
@@ -24,9 +24,6 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.c
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-master.cnf.template > /etc/my.cnf.d/master.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-repl-gtid.cnf.template > /etc/my.cnf.d/repl-gtid.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
-if [[ "$MYSQL_VERSION" < "5.7" ]] ; then
-  envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning-56-low.cnf.template > /etc/my.cnf.d/tuning-56-low.cnf
-fi
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.7/root/usr/bin/run-mysqld-slave
+++ b/5.7/root/usr/bin/run-mysqld-slave
@@ -25,9 +25,6 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.c
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-slave.cnf.template > /etc/my.cnf.d/slave.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-repl-gtid.cnf.template > /etc/my.cnf.d/repl-gtid.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
-if [[ "$MYSQL_VERSION" < "5.7" ]] ; then
-  envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning-56-low.cnf.template > /etc/my.cnf.d/tuning-56-low.cnf
-fi
 
 if [ ! -e "${MYSQL_DATADIR}/mysql" ]; then
   # Initialize MySQL database and wait for the MySQL master to accept

--- a/5.7/root/usr/share/container-scripts/mysql/my-tuning-56-low.cnf.template
+++ b/5.7/root/usr/share/container-scripts/mysql/my-tuning-56-low.cnf.template
@@ -1,2 +1,0 @@
-[mysqld]
-innodb_additional_mem_pool_size = 2M


### PR DESCRIPTION
Option `innodb_additional_mem_pool_size` has been deprecated since version 5.6 and also it has no effect unless `innodb_use_sys_malloc` is turned off, which is not in our case.

See more at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_additional_mem_pool_size
