### PR TITLE
bz1505037: Introduce DEBUG_IGNORE_SCRIPT_FAILURES option to rescue from failure of the setup script

### DIFF
--- a/5.5/root/usr/share/container-scripts/mysql/passwd-change.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/passwd-change.sh
@@ -1,3 +1,4 @@
+set +e
 # Set the password for MySQL user and root everytime this container is started.
 # This allows to change the password by editing the deployment configuration.
 if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
@@ -22,4 +23,4 @@ else
     FLUSH PRIVILEGES;
 EOSQL
 fi
-
+set -e

--- a/5.5/root/usr/share/container-scripts/mysql/passwd-change.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/passwd-change.sh
@@ -1,4 +1,3 @@
-set +e
 # Set the password for MySQL user and root everytime this container is started.
 # This allows to change the password by editing the deployment configuration.
 if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
@@ -23,4 +22,3 @@ else
     FLUSH PRIVILEGES;
 EOSQL
 fi
-set -e

--- a/root-common/usr/bin/run-mysqld
+++ b/root-common/usr/bin/run-mysqld
@@ -3,6 +3,9 @@
 export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
+if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+  set +e
+fi
 
 export_setting_variables
 

--- a/root-common/usr/bin/run-mysqld-master
+++ b/root-common/usr/bin/run-mysqld-master
@@ -6,6 +6,9 @@
 export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
+if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+  set +e
+fi
 
 export_setting_variables
 

--- a/root-common/usr/bin/run-mysqld-slave
+++ b/root-common/usr/bin/run-mysqld-slave
@@ -6,6 +6,9 @@
 export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
+if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+  set +e
+fi
 
 export_setting_variables
 

--- a/root-common/usr/share/container-scripts/mysql/helpers.sh
+++ b/root-common/usr/share/container-scripts/mysql/helpers.sh
@@ -21,4 +21,7 @@ function log_volume_info {
     shift
   done
   set -e
+  if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+    set +e
+  fi
 }


### PR DESCRIPTION
Since run-mysqld sets `set -eu`, if commands returned non 0 result
inside passwd-change.sh, mysql container does not start. Due to this,
if mysql command starts failing inside passwd-change.sh, mysql does
not run and we cannot debug it.

This patch introduces `set +e` inside the script and ignore the
user/password creation error, so users can debug mysql after it starts
running.