### PR TITLE
bz1505037: Add debugging info into passwd-change script

### DIFF
--- a/root-common/usr/share/container-scripts/mysql/helpers.sh
+++ b/root-common/usr/share/container-scripts/mysql/helpers.sh
@@ -7,6 +7,14 @@ function log_and_run {
   "$@"
 }
 
+function log_debug {
+  CONTAINER_DEBUG=${CONTAINER_DEBUG:-}
+  if [[ "${CONTAINER_DEBUG,,}" != "true" ]]; then
+    return
+  fi
+  log_info $@
+}
+
 function log_volume_info {
   CONTAINER_DEBUG=${CONTAINER_DEBUG:-}
   if [[ "${CONTAINER_DEBUG,,}" != "true" ]]; then


### PR DESCRIPTION
This is a different approach to fix lack of debugging information in passwd-change script, which was originally reported in https://bugzilla.redhat.com/show_bug.cgi?id=1505037 and #199.

<!-- issue-commentator = {"comment-id":"2383155839"} -->