### PR TITLE
[DO NOT MERGE] Revert "Do not use VOLUME command in Dockerfiles"

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -70,9 +70,7 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
 
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
+VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -70,9 +70,7 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
 
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
+VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -70,9 +70,7 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
 
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
+VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/5.7/Dockerfile.fedora
+++ b/5.7/Dockerfile.fedora
@@ -71,9 +71,7 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
 
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
+VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/5.7/Dockerfile.rhel7
+++ b/5.7/Dockerfile.rhel7
@@ -70,9 +70,7 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
 
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
+VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 


### PR DESCRIPTION
This reverts commit 987e5c5e4e7cda060246e5d0007f2dca26516ab3, because it breaks things: https://github.com/openshift/origin/pull/19470