### PR TITLE
Increase memory in the test because 8.0 simply does not work with just 256M any more

### DIFF
--- a/test/run
+++ b/test/run
@@ -339,7 +339,7 @@ function run_configuration_tests() {
 
   container_name=dynamic_config_test
 
-  DOCKER_ARGS='--memory=256m' create_container \
+  DOCKER_ARGS='--memory=512m' create_container \
     "$container_name" \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
@@ -349,11 +349,11 @@ function run_configuration_tests() {
 
   configuration="$(docker exec -t "$(ct_get_cid $container_name)" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
 
-  test_config_option "$container_name" "$configuration" key_buffer_size 25M
-  test_config_option "$container_name" "$configuration" read_buffer_size 12M
-  test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 128M
-  test_config_option "$container_name" "$configuration" innodb_log_file_size 38M
-  test_config_option "$container_name" "$configuration" innodb_log_buffer_size 38M
+  test_config_option "$container_name" "$configuration" key_buffer_size 51M
+  test_config_option "$container_name" "$configuration" read_buffer_size 25M
+  test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 256M
+  test_config_option "$container_name" "$configuration" innodb_log_file_size 76M
+  test_config_option "$container_name" "$configuration" innodb_log_buffer_size 76M
 
   docker stop "$(ct_get_cid $container_name)" >/dev/null
 


### PR DESCRIPTION
Also removing cgroup-limits binary as it is already in s2i-core image.