### PR TITLE
remove shadow-utils from rpm -V check on rhel8

### DIFF
--- a/8.0/Dockerfile.rhel8
+++ b/8.0/Dockerfile.rhel8
@@ -38,8 +38,8 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable mysql:$MYSQL_VERSION && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base shadow-utils mysql-server" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS shadow-utils && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \


### PR DESCRIPTION
because there are some file capabilities dropped in container