### PR TITLE
Add Dockerfile.rhel7 for v8.0

### DIFF
--- a/8.0/.exclude-rhel7
+++ b/8.0/.exclude-rhel7
@@ -1,1 +1,0 @@
-RHEL-7 variant not yet ready

--- a/8.0/Dockerfile.rhel7
+++ b/8.0/Dockerfile.rhel7
@@ -1,0 +1,80 @@
+FROM rhscl/s2i-core-rhel7:1
+
+# MySQL image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MySQL
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=8.0 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql
+
+ENV SUMMARY="MySQL 8.0 SQL database server" \
+    DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MySQL mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MySQL databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MySQL 8.0" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mysql80,rh-mysql80" \
+      com.redhat.component="rh-mysql80-container" \
+      name="rhscl/mysql-80-rhel7" \
+      version="8.0" \
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mysql-80-rhel7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
+    INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils rh-mysql80" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/opt/rh/rh-mysql80/root/usr \
+    ENABLED_COLLECTIONS=rh-mysql80
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+COPY 8.0/root-common /
+COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 8.0/root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Versions
 ---------------
 MySQL versions currently provided are:
 * [MySQL 5.7](5.7)
+* [MySQL 8.0](8.0)
 
 RHEL versions currently supported are:
 * RHEL7
+* RHEL8
 
 CentOS versions currently supported are:
 * CentOS7
@@ -31,11 +33,11 @@ Choose either the CentOS7 or RHEL7 based image:
 
 *  **RHEL7 based image**
 
-    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/mysql-57-rhel7).
+    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/mysql-80-rhel7).
     To download it run:
 
     ```
-    $ podman pull registry.access.redhat.com/rhscl/mysql-57-rhel7
+    $ podman pull registry.access.redhat.com/rhscl/mysql-80-rhel7
     ```
 
     To build a RHEL7 based MySQL image, you need to run Docker build on a properly
@@ -45,7 +47,7 @@ Choose either the CentOS7 or RHEL7 based image:
     $ git clone --recursive https://github.com/sclorg/mysql-container.git
     $ cd mysql-container
     $ git submodule update --init
-    $ make build TARGET=rhel7 VERSIONS=5.7
+    $ make build TARGET=rhel7 VERSIONS=8.0
     ```
 
 *  **CentOS7 based image**
@@ -53,7 +55,7 @@ Choose either the CentOS7 or RHEL7 based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull centos/mysql-57-centos7
+    $ podman pull centos/mysql-80-centos7
     ```
 
     To build a CentOS based MySQL image from scratch, run:
@@ -62,10 +64,10 @@ Choose either the CentOS7 or RHEL7 based image:
     $ git clone --recursive https://github.com/sclorg/mysql-container.git
     $ cd mysql-container
     $ git submodule update --init
-    $ make build TARGET=centos7 VERSIONS=5.7
+    $ make build TARGET=centos7 VERSIONS=8.0
     ```
 
-For using other versions of MySQL, just replace the `5.7` value by particular version
+For using other versions of MySQL, just replace the `8.0` value by particular version
 in the commands above.
 
 Note: while the installation steps are calling `podman`, you can replace any such calls by `docker` with the same arguments.
@@ -80,6 +82,9 @@ Usage
 
 For information about usage of Dockerfile for MySQL 5.7,
 see [usage documentation](5.7).
+
+For information about usage of Dockerfile for MySQL 8.0,
+see [usage documentation](8.0).
 
 
 Test
@@ -98,7 +103,7 @@ Users can choose between testing MySQL based on a RHEL or CentOS image.
     ```
     $ cd mysql-container
     $ git submodule update --init
-    $ make test TARGET=rhel7 VERSIONS=5.7
+    $ make test TARGET=rhel7 VERSIONS=8.0
     ```
 
 *  **CentOS based image**
@@ -106,10 +111,10 @@ Users can choose between testing MySQL based on a RHEL or CentOS image.
     ```
     $ cd mysql-container
     $ git submodule update --init
-    $ make test TARGET=centos7 VERSIONS=5.7
+    $ make test TARGET=centos7 VERSIONS=8.0
     ```
 
-For using other versions of MySQL, just replace the `5.7` value by particular version
+For using other versions of MySQL, just replace the `8.0` value by particular version
 in the commands above.
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed

--- a/examples/mysql-ephemeral-template.json
+++ b/examples/mysql-ephemeral-template.json
@@ -5,7 +5,7 @@
     "name": "mysql-ephemeral",
     "annotations": {
       "openshift.io/display-name": "MySQL (Ephemeral)",
-      "description": "MySQL database service, without persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/5.7/root/usr/share/container-scripts/mysql/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+      "description": "MySQL database service, without persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
       "iconClass": "icon-mysql-database",
       "tags": "database,mysql",
       "openshift.io/long-description": "This template provides a standalone MySQL server with a database created.  The database is not stored on persistent storage, so any restart of the service will result in all data being lost.  The database name, username, and password are chosen via parameters when provisioning this service.",
@@ -14,7 +14,7 @@
       "openshift.io/support-url": "https://access.redhat.com"
     }
   },
-  "message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/5.7/root/usr/share/container-scripts/mysql/README.md.",
+  "message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.",
   "labels": {
     "template": "mysql-ephemeral-template"
   },
@@ -265,8 +265,8 @@
     {
       "name": "MYSQL_VERSION",
       "displayName": "Version of MySQL Image",
-      "description": "Version of MySQL image to be used (5.7, or latest).",
-      "value": "5.7",
+      "description": "Version of MySQL image to be used (8.0, or latest).",
+      "value": "8.0",
       "required": true
     }
   ]

--- a/examples/mysql-persistent-template.json
+++ b/examples/mysql-persistent-template.json
@@ -5,7 +5,7 @@
     "name": "mysql-persistent",
     "annotations": {
       "openshift.io/display-name": "MySQL",
-      "description": "MySQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/5.7/root/usr/share/container-scripts/mysql/README.md.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.",
+      "description": "MySQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.",
       "iconClass": "icon-mysql-database",
       "tags": "database,mysql",
       "openshift.io/long-description": "This template provides a standalone MySQL server with a database created.  The database is stored on persistent storage.  The database name, username, and password are chosen via parameters when provisioning this service.",
@@ -14,7 +14,7 @@
       "openshift.io/support-url": "https://access.redhat.com"
     }
   },
-  "message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/5.7/root/usr/share/container-scripts/mysql/README.md.",
+  "message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.",
   "labels": {
     "template": "mysql-persistent-template"
   },
@@ -270,8 +270,8 @@
     {
       "name": "MYSQL_VERSION",
       "displayName": "Version of MySQL Image",
-      "description": "Version of MySQL image to be used (5.7, or latest).",
-      "value": "5.7",
+      "description": "Version of MySQL image to be used (8.0, or latest).",
+      "value": "8.0",
       "required": true
     }
   ]

--- a/imagestreams/mysql-rhel7-ppc64le.json
+++ b/imagestreams/mysql-rhel7-ppc64le.json
@@ -20,7 +20,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "5.7"
+          "name": "8.0"
         },
         "referencePolicy": {
           "type": "Local"
@@ -39,6 +39,24 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/rhscl/mysql-57-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8.0",
+        "annotations": {
+          "openshift.io/display-name": "MySQL 8.0",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MySQL 8.0 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
+          "iconClass": "icon-mysql-database",
+          "tags": "mysql,ppc64le",
+          "version": "8.0"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/mysql-80-rhel7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Part of this, the following was changed:
- image streams for ppc64le (add 8.0 version)
- example templates include 8.0 as default version
- updates README.md in the root and includes v8.0 in examples