### PR TITLE
Fixes BZ#1653215 Operation ALTER USER failed

### DIFF
--- a/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
+++ b/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
@@ -4,9 +4,22 @@ password_change() {
   # Set the password for MySQL user and root everytime this container is started.
   # This allows to change the password by editing the deployment configuration.
   if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
-mysql $mysql_flags <<EOSQL
-      ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
+    TMP_FILE=$(mktemp /tmp/mysql_userXXXXX)
+mysql $mysql_flags >> $TMP_FILE <<EOSQL
+      SELECT user FROM mysql.user;
 EOSQL
+    grep -Fxq "$MYSQL_USER" "$TMP_FILE" > /dev/null
+    RETCODE=$?
+    if [[ $RETCODE -eq 0 ]]; then
+  mysql $mysql_flags <<EOSQL
+        ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
+EOSQL
+    else
+      log_info "User ${MYSQL_USER} does not exist in database."
+    fi
+    rm "${TMP_FILE}"
+    unset TMP_FILE
+
   fi
 
   # The MYSQL_ROOT_PASSWORD is optional, therefore we need to either enable remote

--- a/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
+++ b/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
@@ -4,21 +4,16 @@ password_change() {
   # Set the password for MySQL user and root everytime this container is started.
   # This allows to change the password by editing the deployment configuration.
   if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
-    TMP_FILE=$(mktemp /tmp/mysql_userXXXXX)
-mysql $mysql_flags >> $TMP_FILE <<EOSQL
-      SELECT user FROM mysql.user;
-EOSQL
-    grep -Fxq "$MYSQL_USER" "$TMP_FILE" > /dev/null
-    RETCODE=$?
-    if [[ $RETCODE -eq 0 ]]; then
+    USERS=$(echo "SELECT user FROM mysql.user;" | mysql $mysql_flags)
+    USERS=$(echo "${USERS}" | tr '\n' ' ')
+    if [[ "$USERS" == *"${MYSQL_USER}"* ]]; then
   mysql $mysql_flags <<EOSQL
         ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
 EOSQL
     else
       log_info "User ${MYSQL_USER} does not exist in database."
     fi
-    rm "${TMP_FILE}"
-    unset TMP_FILE
+    unset USERS
 
   fi
 

--- a/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
+++ b/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
@@ -4,17 +4,14 @@ password_change() {
   # Set the password for MySQL user and root everytime this container is started.
   # This allows to change the password by editing the deployment configuration.
   if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
-    USERS=$(echo "SELECT user FROM mysql.user;" | mysql $mysql_flags)
-    USERS=$(echo "${USERS}" | tr '\n' ' ')
-    if [[ "$USERS" == *"${MYSQL_USER}"* ]]; then
-  mysql $mysql_flags <<EOSQL
-        ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
-EOSQL
+    local user_maches=$(echo "SELECT COUNT(*) AS found FROM mysql.user WHERE user='${MYSQL_USER}' AND Host='%' \G" | mysql $mysql_flags)
+    if ! echo "${user_maches}" | grep -q 'found: 1' ; then
+      log_info "WARNING: User ${MYSQL_USER} does not exist in database. Password not changed."
     else
-      log_info "User ${MYSQL_USER} does not exist in database."
+mysql $mysql_flags <<EOSQL
+      ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
+EOSQL
     fi
-    unset USERS
-
   fi
 
   # The MYSQL_ROOT_PASSWORD is optional, therefore we need to either enable remote

--- a/test/run
+++ b/test/run
@@ -154,7 +154,7 @@ function run_change_password_new_user_test() {
   test_connection testpassnewuser2 user foo
 
   # See whether there is an error message in the log
-  if ! docker logs $(ct_get_cid testpassnewuser2) | grep 'User .*user2.* does not exist in database' ; then
+  if ! docker logs $(ct_get_cid testpassnewuser2) | grep 'User user2 does not exist in database' ; then
     echo "ERROR: Container did not end with expected error message: 'User user2 does not exist in database'."
     return 1
   fi

--- a/test/run
+++ b/test/run
@@ -18,6 +18,7 @@ run_container_creation_tests
 run_configuration_tests
 run_general_tests
 run_change_password_test
+run_change_password_new_user_test
 run_replication_test
 run_doc_test
 run_s2i_test
@@ -133,6 +134,34 @@ function run_change_password_test() {
 
   # The old password should not work anymore
   if mysql_cmd "$(ct_get_cip testpass2)" user foo -e 'SELECT 1;'; then
+    return 1
+  fi
+}
+
+function run_change_password_new_user_test() {
+  local tmpdir=$(mktemp -d)
+  chmod -R a+rwx "${tmpdir}"
+
+  # Create MySQL container with persistent volume and set the initial password
+  create_container "testpassnewuser1" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${tmpdir}:/var/lib/mysql/data:Z
+  test_connection testpassnewuser1 user foo
+  docker stop $(ct_get_cid testpassnewuser1) >/dev/null
+
+  # Create second container with changed password
+  create_container "testpassnewuser2" -e MYSQL_USER=user2 -e MYSQL_PASSWORD=bar \
+    -e MYSQL_DATABASE=db -v ${tmpdir}:/var/lib/mysql/data:Z
+  test_connection testpassnewuser2 user foo
+
+  # See whether there is an error message in the log
+  if ! docker logs $(ct_get_cid testpassnewuser2) | grep 'User .*user2.* does not exist in database' ; then
+    echo "ERROR: Container did not end with expected error message: 'User user2 does not exist in database'."
+    return 1
+  fi
+
+  # The new password should not work
+  if mysql_cmd "$(ct_get_cip testpassnewuser2)" user bar -e 'SELECT 1;'; then
+    echo "ERROR: The new password should not work, but it does."
     return 1
   fi
 }


### PR DESCRIPTION
This issue fixes BZ#1653215.

This commit fixes problem formatting MySQL commands
in 50-passwd-change.sh script.
Correct BASH syntax as an input to MySQL command is used.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>