### PR TITLE
Add MYSQL_DEFAULT_AUTHENTICATION_PLUGIN option

### DIFF
--- a/8.0/root/usr/share/container-scripts/mysql/README.md
+++ b/8.0/root/usr/share/container-scripts/mysql/README.md
@@ -114,6 +114,8 @@ The following environment variables influence the MySQL configuration file. They
 **`MYSQL_LOG_QUERIES_ENABLED (default: 0)`**  
        To enable query logging set this to `1`
 
+**`MYSQL_DEFAULT_AUTHENTICATION_PLUGIN (default: caching_sha2_password)`**  
+       Set default authentication plugin. Accepts values `mysql_native_password` or `caching_sha2_password`.
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
@@ -341,6 +343,19 @@ Some applications may wish to use `row` binlog_formats (for example, those built
   with `master` replication turned on (ie, set the Docker/container `cmd` to be
 `run-mysqld-master`) the binlog will emit the actual data for the rows that change
 as opposed to the statements (ie, DML like insert...) that caused the change.
+
+
+Changing the authentication plugin
+----------------------------------
+MySQL 8.0 introduced 'caching_sha2_password' as its default authentication plugin.
+It is faster and provides better security then the previous default authentication plugin.
+However, not all software implements this algorithm, and client applications might report
+issue like "The server requested authentication method".
+
+The plugin can be changed by setting `MYSQL_DEFAULT_AUTHENTICATION_PLUGIN` environment variable,
+which accepts values `caching_sha2_password` (the default one) or `mysql_native_password`.
+To change the behaviour back to the same behavior as MySQL 5.7 (for client applications that do not
+support `caching_sha2_password`), set the `MYSQL_DEFAULT_AUTHENTICATION_PLUGIN=mysql_native_password`.
 
 
 Troubleshooting

--- a/root-common/usr/share/container-scripts/mysql/cnf/20-default-authentication-plugin.cnf
+++ b/root-common/usr/share/container-scripts/mysql/cnf/20-default-authentication-plugin.cnf
@@ -1,0 +1,19 @@
+# MySQL 8.0.4 introduced 'caching_sha2_password' as its default authentication plugin.
+# It is faster and provides better security then the previous default authentication plugin.
+#
+# However, not all software implements this algorithm, and client applications might report
+# issue like "The server requested authentication method"
+#
+# The plugin can be changed by setting default_authentication_plugin variable.
+#
+# The default_authentication_plugin options accepts these values:
+# caching_sha2_password, mysql_native_password
+#
+# To change the behaviour back to the same behavior as MySQL 5.7 had, set the
+# default_authentication_plugin variable to mysql_native_password.
+#
+# Upstream doc at https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html
+
+[mysqld]
+default_authentication_plugin=${MYSQL_DEFAULT_AUTHENTICATION_PLUGIN}
+

--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -43,6 +43,7 @@ function export_setting_variables() {
     export MYSQL_INNODB_LOG_BUFFER_SIZE=${MYSQL_INNODB_LOG_BUFFER_SIZE:-$((MEMORY_LIMIT_IN_BYTES*15/1024/1024/100))M}
   fi
   export MYSQL_DATADIR_ACTION=${MYSQL_DATADIR_ACTION:-upgrade-warn}
+  export MYSQL_DEFAULT_AUTHENTICATION_PLUGIN=${MYSQL_DEFAULT_AUTHENTICATION_PLUGIN:-caching_sha2_password}
 }
 
 # this stores whether the database was initialized from empty datadir

--- a/test/run
+++ b/test/run
@@ -307,6 +307,7 @@ function run_configuration_tests() {
     --env MYSQL_INNODB_BUFFER_POOL_SIZE=16M \
     --env MYSQL_INNODB_LOG_FILE_SIZE=4M \
     --env MYSQL_INNODB_LOG_BUFFER_SIZE=4M \
+    --env MYSQL_DEFAULT_AUTHENTICATION_PLUGIN=mysql_native_password \
     --env WORKAROUND_DOCKER_BUG_14203=
     #
 
@@ -331,6 +332,7 @@ function run_configuration_tests() {
   test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 16M
   test_config_option "$container_name" "$configuration" innodb_log_file_size 4M
   test_config_option "$container_name" "$configuration" innodb_log_buffer_size 4M
+  test_config_option "$container_name" "$configuration" default_authentication_plugin mysql_native_password
 
   docker stop "$(ct_get_cid $container_name)" >/dev/null
 
@@ -354,6 +356,9 @@ function run_configuration_tests() {
   test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 256M
   test_config_option "$container_name" "$configuration" innodb_log_file_size 76M
   test_config_option "$container_name" "$configuration" innodb_log_buffer_size 76M
+
+  # here we test the default value for default_authentication_plugin
+  test_config_option "$container_name" "$configuration" default_authentication_plugin caching_sha2_password
 
   docker stop "$(ct_get_cid $container_name)" >/dev/null
 


### PR DESCRIPTION
MySQL 8.0 introduced 'caching_sha2_password' as its default authentication plugin.
It is faster and provides better security then the previous default authentication plugin.
However, not all software implements this algorithm, and client applications might report
issue like "The server requested authentication method".

An example of such error: https://bugzilla.redhat.com/show_bug.cgi?id=1793116

Solution:

The plugin can be changed by setting `MYSQL_DEFAULT_AUTHENTICATION_PLUGIN` environment variable,
which accepts values `caching_sha2_password` (the default one) or `mysql_native_password`.
To change the behaviour back to the same behavior as MySQL 5.7 (for client applications that do not
support `caching_sha2_password`), set the `MYSQL_DEFAULT_AUTHENTICATION_PLUGIN=mysql_native_password`.

We keep `caching_sha2_password` as default because it has been default for long time and we should
not just change the config default. Since we didn't have many reports, it looks like users don't have
that many problems with the new authentication plugin. We should still offer a way to change it though.