### PR TITLE
create more than one database when init container

### DIFF
--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -169,15 +169,18 @@ EOSQL
   fi
 
   if [ -v MYSQL_DATABASE ]; then
-    log_info "Creating database ${MYSQL_DATABASE} ..."
-    mysqladmin $admin_flags create "${MYSQL_DATABASE}"
+    # split MYSQL_DATABASE by ,
+    for item in $(echo "${MYSQL_DATABASE}" | tr "," "\n"); do
+    log_info "Creating database ${item} ..."
+    mysqladmin $admin_flags create "${item}"
     if [ -v MYSQL_USER ]; then
-      log_info "Granting privileges to user ${MYSQL_USER} for ${MYSQL_DATABASE} ..."
+      log_info "Granting privileges to user ${MYSQL_USER} for ${item} ..."
 mysql $mysql_flags <<EOSQL
-      GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
+      GRANT ALL ON \`${item}\`.* TO '${MYSQL_USER}'@'%' ;
       FLUSH PRIVILEGES ;
 EOSQL
     fi
+    done
   fi
 
   log_info 'Initialization finished'

--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -52,6 +52,7 @@ export MYSQL_DATADIR_FIRST_INIT=false
 # Be paranoid and stricter than we should be.
 # https://dev.mysql.com/doc/refman/en/identifiers.html
 mysql_identifier_regex='^[a-zA-Z0-9_]+$'
+mysql_dbname_identifier_regex='^[a-zA-Z0-9_,]+$'
 mysql_password_regex='^[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]+$'
 
 # Variables that are used to connect to local mysql during initialization

--- a/root-common/usr/share/container-scripts/mysql/pre-init/20-validate-variables.sh
+++ b/root-common/usr/share/container-scripts/mysql/pre-init/20-validate-variables.sh
@@ -3,7 +3,7 @@ function usage() {
   echo "You must either specify the following environment variables:"
   echo "  MYSQL_USER (regex: '$mysql_identifier_regex')"
   echo "  MYSQL_PASSWORD (regex: '$mysql_password_regex')"
-  echo "  MYSQL_DATABASE (regex: '$mysql_identifier_regex')"
+  echo "  MYSQL_DATABASE (regex: '$mysql_dbname_identifier_regex')"
   echo "Or the following environment variable:"
   echo "  MYSQL_ROOT_PASSWORD (regex: '$mysql_password_regex')"
   echo "Or both."
@@ -65,7 +65,7 @@ function validate_variables() {
   fi
 
   if [ -v MYSQL_DATABASE ]; then
-    [[ "$MYSQL_DATABASE" =~ $mysql_identifier_regex ]] || usage "Invalid database name"
+    [[ "$MYSQL_DATABASE" =~ $mysql_dbname_identifier_regex ]] || usage "Invalid database name"
     [ ${#MYSQL_DATABASE} -le 64 ] || usage "Database name too long (maximum 64 characters)"
   fi
 


### PR DESCRIPTION

Try to make this [feature](https://github.com/sclorg/mysql-container/issues/286)

Now MYSQL_DATABASE accept more than one database name ,split by ","

<!-- issue-commentator = {"comment-id":"2383155695"} -->