### PR TITLE
Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/8.0/Dockerfile.fedora
+++ b/8.0/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f31/s2i-core:latest
+FROM registry.fedoraproject.org/f32/s2i-core:latest
 
 # MySQL image for OpenShift.
 #
@@ -14,7 +14,7 @@ ENV MYSQL_VERSION=8.0 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql
 
-ENV SUMMARY="MySQL 8.0 SQL database server" \
+ENV SUMMARY="MySQL $MYSQL_VERSION SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -26,7 +26,7 @@ ENV NAME=mysql \
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      io.k8s.display-name="MySQL 8.0" \
+      io.k8s.display-name="MySQL $MYSQL_VERSION" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mysql80,rh-mysql80" \
       com.redhat.component="$NAME" \

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -18,6 +18,8 @@ trap ct_os_cleanup EXIT SIGINT
 
 ct_os_check_compulsory_vars
 
+ct_os_enable_print_logs
+
 ct_os_cluster_up
 
 test_mysql_pure_image "${IMAGE_NAME}"
@@ -28,19 +30,35 @@ test_mysql_template "${IMAGE_NAME}"
 test_mysql_s2i "${IMAGE_NAME}" "https://github.com/sclorg/mysql-container.git" test/test-app
 
 # test with the just built image and an integrated template
+echo "Running test_mysql_integration with ${IMAGE_NAME}"
 test_mysql_integration "${IMAGE_NAME}" "${VERSION}" mysql
 
 # test with a released image and an integrated template
+# ignore possible failure of this test for centos images
+fail_not_released=true
 if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.access.redhat.com/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
+  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
 else
   PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
+  fail_not_released=false
 fi
 
-export CT_SKIP_UPLOAD_IMAGE=true
-test_mysql_integration mysql "${VERSION}" "${PUBLIC_IMAGE_NAME}"
+# Try pulling the image first to see if it is accessible
+if docker pull "${PUBLIC_IMAGE_NAME}"; then
+  echo "Running test_mysql_integration with ${PUBLIC_IMAGE_NAME}"
+  test_mysql_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" mysql
+else
+  echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
+  ! $fail_not_released || false "ERROR: Failed to pull image"
+fi
+
+# Check the imagestream
+echo "Running test_mysql_imagestream"
+test_mysql_imagestream
 
 OS_TESTSUITE_RESULT=0
 
 ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -31,25 +31,20 @@ test_mysql_s2i "${IMAGE_NAME}" "https://github.com/sclorg/mysql-container.git" t
 
 # test with the just built image and an integrated template
 echo "Running test_mysql_integration with ${IMAGE_NAME}"
-test_mysql_integration "${IMAGE_NAME}" "${VERSION}" mysql
+test_mysql_integration "${IMAGE_NAME}"
 
 # test with a released image and an integrated template
 # ignore possible failure of this test for centos images
-fail_not_released=true
-if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
-else
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
-  fail_not_released=false
-fi
+PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
 
 # Try pulling the image first to see if it is accessible
 if docker pull "${PUBLIC_IMAGE_NAME}"; then
   echo "Running test_mysql_integration with ${PUBLIC_IMAGE_NAME}"
-  test_mysql_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" mysql
+  test_mysql_integration "${PUBLIC_IMAGE_NAME}"
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
-  ! $fail_not_released || false "ERROR: Failed to pull image"
+  # ignore possible failure of this test for centos images
+  [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
 fi
 
 # Check the imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -25,7 +25,7 @@ export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
 # Check the template
-test_mysql_integration "${IMAGE_NAME}" ${VERSION} mysql
+test_mysql_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_mysql_imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,13 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_mysql_integration mysql ${VERSION} "registry.access.redhat.com/${IMAGE_NAME}"
+# Check the template
+test_mysql_integration "${IMAGE_NAME}" ${VERSION} mysql
+
+# Check the imagestream
+test_mysql_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -113,9 +113,7 @@ function test_mysql_s2i() {
 
 function test_mysql_integration() {
   local image_name=$1
-  local VERSION=$2
-  local service_name=$3
-  local image_tagged="${service_name}:${VERSION}"
+  local service_name=mysql
   ct_os_template_exists mysql-ephemeral && t=mysql-ephemeral || t=mysql-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -114,17 +114,29 @@ function test_mysql_s2i() {
 function test_mysql_integration() {
   local image_name=$1
   local VERSION=$2
-  local import_image=$3
-  local service_name=${import_image##*/}
+  local service_name=$3
+  local image_tagged="${service_name}:${VERSION}"
   ct_os_template_exists mysql-ephemeral && t=mysql-ephemeral || t=mysql-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \
                                "${service_name}" \
-                               "ct_os_check_cmd_internal '${import_image}' '${service_name}' \"echo 'SELECT 42 as testval\g' | mysql --connect-timeout=15 -h <IP> testdb -utestu -ptestp\" '^42' 120" \
+                               "ct_os_check_cmd_internal '<SAME_IMAGE>' '${service_name}-testing' \"echo 'SELECT 42 as testval\g' | mysql --connect-timeout=15 -h <IP> testdb -utestu -ptestp\" '^42' 120" \
                                "-p MYSQL_VERSION=${VERSION} \
                                 -p DATABASE_SERVICE_NAME="${service_name}-testing" \
                                 -p MYSQL_USER=testu \
                                 -p MYSQL_PASSWORD=testp \
-                                -p MYSQL_DATABASE=testdb" "" "${import_image}"
+                                -p MYSQL_DATABASE=testdb"
 }
 
+
+# Check the imagestream
+function test_mysql_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mysql-${OS}.json" "${THISDIR}/../examples/mysql-ephemeral-template.json" mysql "-p MYSQL_VERSION=${VERSION}"
+}
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster
