### PR TITLE
Support quay.io registry

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7
+FROM quay.io/centos7/s2i-core-centos7
 
 # MySQL image for OpenShift.
 #
@@ -29,9 +29,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mysql80,rh-mysql80" \
       com.redhat.component="rh-mysql80-container" \
-      name="centos/mysql-80-centos7" \
+      name="centos7/mysql-80-centos7" \
       version="8.0" \
-      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 centos/mysql-80-centos7" \
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/centos7/mysql-80-centos7" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306

--- a/8.0/root/usr/share/container-scripts/mysql/README.md
+++ b/8.0/root/usr/share/container-scripts/mysql/README.md
@@ -1,10 +1,10 @@
 MySQL 8.0 SQL Database Server container image
-==========================================
+=============================================
 
 This container image includes MySQL 8.0 SQL database server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -159,7 +159,7 @@ calculated based on the available memory.
 
 
 MySQL root user
----------------------------------
+---------------
 The root user has no password set by default, only allowing local connections.
 You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
 will allow you to login to the root account remotely. Local connections will

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 MySQL SQL Database Server Container Image
-======================================
+=========================================
+MySQL 8.0 status: [![Docker Repository on Quay](https://quay.io/repository/centos7/mysql-80-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/mysql-80-centos7)
 
 This repository contains Dockerfiles for MySQL images for OpenShift and general usage.
 Users can choose between RHEL, Fedora and CentOS based images.
@@ -14,7 +15,7 @@ For more information about concepts used in these container images, see the
 
 
 Versions
----------------
+--------
 MySQL versions currently provided are:
 * [MySQL 8.0](8.0)
 
@@ -27,7 +28,7 @@ CentOS versions currently supported are:
 
 
 Installation
-----------------------
+------------
 Choose either the CentOS7 or RHEL7 based image:
 
 *  **RHEL7 based image**
@@ -54,7 +55,7 @@ Choose either the CentOS7 or RHEL7 based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull centos/mysql-80-centos7
+    $ podman pull quay.io/centos7/mysql-80-centos7
     ```
 
     To build a CentOS based MySQL image from scratch, run:
@@ -77,14 +78,14 @@ This variable must be set to a list with possible versions (subdirectories).**
 
 
 Usage
----------------------------------
+-----
 
 For information about usage of Dockerfile for MySQL 8.0,
 see [usage documentation](8.0).
 
 
 Test
----------------------------------
+----
 
 This repository also provides a test framework, which checks basic functionality
 of the MySQL image.

--- a/imagestreams/mysql-centos.json
+++ b/imagestreams/mysql-centos.json
@@ -56,7 +56,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/mysql-80-centos7:latest"
+          "name": "quay.io/centos7/mysql-80-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -74,7 +74,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/mysql-80-centos7:latest"
+          "name": "quay.io/centos7/mysql-80-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
This pull request supports Quay.io registry instead of Docker.io
registry because of rate limits.
Rate limits were introduced by Docker recently.