### PR TITLE
Support testing mysql-container under OpenShift 4 environment

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -20,9 +20,10 @@ ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-export CT_SKIP_NEW_PROJECT=true
-export CT_SKIP_UPLOAD_IMAGE=true
-export CT_NAMESPACE=openshift
+# For testing on OpenShift 4 we use external registry
+export CT_EXTERNAL_REGISTRY=true
+
+ct_os_set_ocp4
 
 # Check the template
 test_mysql_integration "${IMAGE_NAME}"

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -10,6 +10,7 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source ${THISDIR}/test-lib.sh
 source ${THISDIR}/test-lib-openshift.sh
+source ${THISDIR}/test-lib-remote-openshift.sh
 
 function check_mysql_os_service_connection() {
   local util_image_name="${1}" ; shift
@@ -63,7 +64,7 @@ function test_mysql_pure_image() {
 }
 
 function test_mysql_template() {
-  local image_name=${1:-centos/mysql-80-centos7}
+  local image_name=${1:-quay.io/centos7/mysql-80-centos7}
   local image_name_no_namespace=${image_name##*/}
   local service_name=${image_name_no_namespace}
 
@@ -85,7 +86,7 @@ function test_mysql_template() {
 }
 
 function test_mysql_s2i() {
-  local image_name=${1:-centos/mysql-80-centos7}
+  local image_name=${1:-quay.io/centos7/mysql-80-centos7}
   local app=${2:-https://github.com/sclorg/mysql-container.git}
   local context_dir=${3:-test/test-app}
   local image_name_no_namespace=${image_name##*/}

--- a/test/test-lib-remote-openshift.sh
+++ b/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../common/test-lib-remote-openshift.sh


### PR DESCRIPTION
This pull request adds support to test mysql-container under OpenShift 4 Jenkins CI .

It is easy, just add [test-openshift-4] comment into PR.