### PR TITLE
Use groupified apiVersion

### DIFF
--- a/examples/mysql-ephemeral-template.json
+++ b/examples/mysql-ephemeral-template.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "mysql-ephemeral",
     "annotations": {
@@ -69,7 +69,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {

--- a/examples/mysql-persistent-template.json
+++ b/examples/mysql-persistent-template.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "mysql-persistent",
     "annotations": {
@@ -78,7 +78,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {

--- a/imagestreams/mysql-centos.json
+++ b/imagestreams/mysql-centos.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "mysql",
     "annotations": {

--- a/imagestreams/mysql-rhel-aarch64.json
+++ b/imagestreams/mysql-rhel-aarch64.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "mysql",
     "annotations": {

--- a/imagestreams/mysql-rhel.json
+++ b/imagestreams/mysql-rhel.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "mysql",
     "annotations": {


### PR DESCRIPTION
Non-groupified objects were deprecated in OCP 4.7.
