### PR TITLE
Fix OpenShift failures

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -16,14 +16,14 @@ set -eo nounset
 
 trap ct_os_cleanup EXIT SIGINT
 
+ct_os_set_ocp4
+
 ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
 # For testing on OpenShift 4 we use external registry
 export CT_EXTERNAL_REGISTRY=true
-
-ct_os_set_ocp4
 
 # Check the template
 test_mysql_integration "${IMAGE_NAME}"


### PR DESCRIPTION
This pull request fixes OpenShift failures.

service name has to have proper name like `mysql-80:testing` and not `mysql:8.0:testing`

Also setting oc binary variable has to be called at the beginning.