### PR TITLE
Support for testing image in CentOS Stream 9

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,4 +1,4 @@
-name: Build and push CentOS7 images to Quay.io registry
+name: Build and push images to Quay.io registry
 on:
   push:
     branches:
@@ -8,8 +8,18 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        version: ["8.0"]
+        include:
+          - version: "8.0"
+            dockerfile: "Dockerfile"
+            registry_namespace: "centos7"
+            tag: "centos7"
+          - version: "8.0"
+            dockerfile: "Dockerfile.c9s"
+            registry_namespace: "sclorg"
+            tag: "c9s"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -28,40 +38,58 @@ jobs:
           ver="${{ matrix.version }}"
           echo "::set-output name=SHORT_VER::${ver//./}"
 
-      - name: Check if dockerfile is present in version directory
-        id: check_dockerfile_file
+      - name: Login to Quay.io private registry
+        if: ${{ matrix.registry_namespace == 'sclorg' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
+
+      - name: Check if .exclude-${{ matrix.tag }} is present in version directory
+        id: check_exclude_file
         # https://github.com/marketplace/actions/file-existence
         uses: andstor/file-existence-action@v1
         with:
-          files: "${{ matrix.version }}/Dockerfile"
+          files: "${{ matrix.version }}/.exclude-${{ matrix.tag }}"
 
-      - name: Check if .exclude-centos7 is present in version directory
-        id: check_exclude_centos7_file
-        # https://github.com/marketplace/actions/file-existence
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ matrix.version }}/.exclude-centos7"
-
-      - name: Build CentOS7 image
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
+      - name: Build image
+        if: steps.check_exclude_file.outputs.files_exists == 'false'
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
         uses: redhat-actions/buildah-build@v2
         with:
-          dockerfiles: ${{ matrix.version }}/Dockerfile
-          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-centos7
-          tags: latest 1 ${{ github.sha }}
+          dockerfiles: ${{ matrix.version }}/${{ matrix.dockerfile }}
+          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-${{ matrix.tag }}
+          context: ${{ matrix.version }}
+          tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
-      - name: Push CentOS7 image to Quay.io
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
-        id: push-to-quay
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && matrix.registry_namespace == 'centos7' }}
+        id: push-to-quay-centos7
         uses: redhat-actions/push-to-registry@v2.2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/centos7
+          registry: quay.io/${{ matrix.registry_namespace }}
           username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && matrix.registry_namespace == 'sclorg' }}
+        id: push-to-quay-sclorg
+        uses: redhat-actions/push-to-registry@v2.2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/${{ matrix.registry_namespace }}
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN  }}
+
       - name: Print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        if: ${{ matrix.registry_namespace == 'centos7' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-centos7.outputs.registry-paths }}"
+
+      - name: Print image url
+        if: ${{ matrix.registry_namespace == 'sclorg' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-sclorg.outputs.registry-paths }}"

--- a/8.0/Dockerfile.c9s
+++ b/8.0/Dockerfile.c9s
@@ -1,0 +1,71 @@
+FROM quay.io/sclorg/s2i-core-c9s:c9s
+
+# MySQL image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MySQL
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=8.0 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql
+
+ENV SUMMARY="MySQL 8.0 SQL database server" \
+    DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MySQL mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MySQL databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MySQL 8.0" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mysql80,mysql-80" \
+      com.redhat.component="mysql-80-container" \
+      name="sclorg/mysql-80-c9s" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mysql-80-c9s:c9s" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY 8.0/root-common /
+COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 8.0/root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]


### PR DESCRIPTION
This pull request adds support for testing mysql-container in CentOS Stream 9.

Dockerfile change is:

```
$ diff 8.0/Dockerfile.rhel8 8.0/Dockerfile.c9s
1c1
< FROM ubi8/s2i-core
---
> FROM quay.io/sclorg/s2i-core-c9s:c9s
30c30
<       name="rhel8/mysql-80" \
---
>       name="sclorg/mysql-80-c9s" \
33c33
<       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mysql-80" \
---
>       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mysql-80-c9s:c9s" \
41,42c41
< RUN yum -y module enable mysql:$MYSQL_VERSION && \
<     INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
---
> RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
```
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>