### PR TITLE
Support building testing c8s

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,15 +20,24 @@ jobs:
             tag: "centos7"
             quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
+            suffix: "centos7"
           - dockerfile_path: "8.0"
             dockerfile: "Dockerfile.c9s"
             registry_namespace: "sclorg"
             tag: "c9s"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+            suffix: "c9s"
+          - dockerfile_path: "8.0"
+            dockerfile: "Dockerfile.c8s"
+            registry_namespace: "sclorg"
+            tag: "c8s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+            suffix: "c8s"
     steps:
       - name: Build and push to quay.io registry
-        uses: sclorg/build-and-push-action@v1
+        uses: sclorg/build-and-push-action@v2
         with:
           registry: "quay.io"
           registry_namespace: ${{ matrix.registry_namespace }}
@@ -37,3 +46,4 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           dockerfile_path: ${{ matrix.dockerfile_path }}
           tag: ${{ matrix.tag }}
+          suffix: ${{ matrix.suffix }}

--- a/8.0/Dockerfile.c8s
+++ b/8.0/Dockerfile.c8s
@@ -1,0 +1,71 @@
+FROM quay.io/sclorg/s2i-core-c8s:c8s
+
+# MySQL image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MySQL
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=8.0 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql
+
+ENV SUMMARY="MySQL 8.0 SQL database server" \
+    DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MySQL mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MySQL databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MySQL 8.0" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mysql80,mysql-80" \
+      com.redhat.component="mysql-80-container" \
+      name="sclorg/mysql-80-c8s" \
+      version="1" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mysql-80-c8s" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN yum -y module enable mysql:$MYSQL_VERSION && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY 8.0/root-common /
+COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 8.0/root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/8.0/root/usr/share/container-scripts/mysql/README.md
+++ b/8.0/root/usr/share/container-scripts/mysql/README.md
@@ -4,7 +4,8 @@ MySQL 8.0 SQL Database Server container image
 This container image includes MySQL 8.0 SQL database server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+the CentOS images are available on [Quay.io/centos7](https://quay.io/organization/centos7),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -377,4 +378,6 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mysql-container.
 In that repository, the Dockerfile for CentOS is called Dockerfile, the Dockerfile
 for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
+the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 MySQL SQL Database Server Container Image
 =========================================
+
+[![Build and push images to Quay.io registry](https://github.com/sclorg/mysql-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/mysql-container/actions/workflows/build-and-push.yml)
+
 MySQL 8.0 status: [![Docker Repository on Quay](https://quay.io/repository/centos7/mysql-80-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/mysql-80-centos7)
 
 This repository contains Dockerfiles for MySQL images for OpenShift and general usage.
@@ -25,6 +28,8 @@ RHEL versions currently supported are:
 
 CentOS versions currently supported are:
 * CentOS7
+* CentOS Stream 8
+* CentOS Stream 9
 
 
 Installation


### PR DESCRIPTION
This pull request adds support for building, testing
`mysql-container` in CentOS Stream 8 and pushing image into quay.io.

It also updates documentation.
Diff between `8.0/Dockerfile.rhel8` and `8.0/Dockerfile.c8s` is:

```bash
$ diff 8.0/Dockerfile.rhel8 8.0/Dockerfile.c8s
1c1
< FROM ubi8/s2i-core
---
> FROM quay.io/sclorg/s2i-core-c8s:c8s
30c30
<       name="rhel8/mysql-80" \
---
>       name="sclorg/mysql-80-c8s" \
32,33c32
<       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
<       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mysql-80" \
---
>       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mysql-80-c8s" \
```