### PR TITLE
Support cvp pipeline

### DIFF
--- a/test/examples
+++ b/test/examples
@@ -1,0 +1,1 @@
+../examples/

--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams/

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -10,7 +10,8 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib-mysql.sh
+source "${THISDIR}/test-lib-mysql.sh"
+source "${THISDIR}/test-lib-remote-openshift.sh"
 
 TEST_LIST="\
 test_mysql_integration
@@ -24,6 +25,8 @@ ct_os_set_ocp4
 ct_os_check_compulsory_vars
 
 ct_os_check_login || exit 1
+
+ct_os_tag_image_for_cvp "mysql"
 
 set -u
 

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -130,14 +130,14 @@ function test_mysql_integration() {
 # Check the imagestream
 function test_mysql_imagestream() {
   case ${OS} in
-    rhel7|centos7) ;;
+    rhel7|centos7|rhel8) ;;
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
   local tag="-el7"
   if [ "${OS}" == "rhel8" ]; then
     tag="-el8"
   fi
-  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mysql-${OS%[0-9]*}.json" "${THISDIR}/../examples/mysql-ephemeral-template.json" mysql "-p MYSQL_VERSION=${VERSION}${tag}"
+  ct_os_test_image_stream_template "${THISDIR}/imagestreams/mysql-${OS%[0-9]*}.json" "${THISDIR}/examples/mysql-ephemeral-template.json" mysql "-p MYSQL_VERSION=${VERSION}${tag}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test/test-openshift.yaml
+++ b/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../common/test-openshift.yaml


### PR DESCRIPTION
This pull request allows testing mariadb-container in CVP pipeline.

* common was updated to the latest
* symlink `examples` and `imagestreams` directory were added to `test`. We need to sync them into dist-git as well.
* `run-openshift-remote-cluster` adds import ruby image into OpenShift 4
* `test-lib-mysql` allows testing imagestreams in OpenShift 4 as well.