### PR TITLE
Fix OpenShift 4 tests

### DIFF
--- a/test/check_imagestreams.py
+++ b/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../common/check_imagestreams.py

--- a/test/mysql-persistent-template.json
+++ b/test/mysql-persistent-template.json
@@ -1,0 +1,1 @@
+../examples/mysql-persistent-template.json

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -16,6 +16,7 @@ source "${THISDIR}/test-lib-remote-openshift.sh"
 TEST_LIST="\
 test_mysql_integration
 test_mysql_imagestream
+run_latest_imagestreams
 "
 
 trap ct_os_cleanup EXIT SIGINT


### PR DESCRIPTION
This pull request fixes:

- updates container-common-scripts that were a bit outdated
- adds `run_latest_imagestreams test` even if there are not planned new versions
- fixes `test_mysql_integration` and tests both templates.