### PR TITLE
imagestreams/mysql-centos: Update for C9S

### DIFF
--- a/imagestreams/mysql-centos.json
+++ b/imagestreams/mysql-centos.json
@@ -20,25 +20,61 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "8.0-el8"
+          "name": "8.0-c9s"
         },
         "referencePolicy": {
           "type": "Local"
         }
       },
       {
-        "name": "8.0-el8",
+        "name": "8.0-fc",
         "annotations": {
-          "openshift.io/display-name": "MySQL 8.0 (CentOS 8)",
+          "openshift.io/display-name": "MySQL 8.0 (Fedora)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MySQL 8.0 database on CentOS 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
+          "description": "Provides a MySQL 8.0 database on Fedora. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
           "iconClass": "icon-mysql-database",
           "tags": "mysql",
           "version": "8.0"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/mysql-80-centos8:latest"
+          "name": "quay.io/fedora/mysql-80:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8.0-c9s",
+        "annotations": {
+          "openshift.io/display-name": "MySQL 8.0 (CentOS 9 Stream)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MySQL 8.0 database on CentOS 9 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
+          "iconClass": "icon-mysql-database",
+          "tags": "mysql",
+          "version": "8.0"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/sclorg/mysql-80-c9s:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8.0-c8s",
+        "annotations": {
+          "openshift.io/display-name": "MySQL 8.0 (CentOS 8 Stream)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MySQL 8.0 database on CentOS 8 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
+          "iconClass": "icon-mysql-database",
+          "tags": "mysql",
+          "version": "8.0"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/sclorg/mysql-80-c8s:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -67,14 +103,14 @@
         "annotations": {
           "openshift.io/display-name": "MySQL 8.0",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MySQL 8.0 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
+          "description": "Provides a MySQL 8.0 database on CentOS 9 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
           "iconClass": "icon-mysql-database",
           "tags": "mysql,hidden",
           "version": "8.0"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/centos7/mysql-80-centos7:latest"
+          "name": "quay.io/sclorg/mysql-80-c9s:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Also switch to using the C8S image from quay.io for EL8 instead of pulling from docker.io, avoiding rate-limits.