### PR TITLE
Do not use dead symlink in repository.

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -64,6 +64,11 @@ COPY 8.0/root-common /
 COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 8.0/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -72,9 +77,6 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
 
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/8.0/Dockerfile.c8s
+++ b/8.0/Dockerfile.c8s
@@ -53,6 +53,11 @@ COPY 8.0/root-common /
 COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 8.0/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -61,10 +66,6 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION"
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/8.0/Dockerfile.c9s
+++ b/8.0/Dockerfile.c9s
@@ -53,6 +53,11 @@ COPY 8.0/root-common /
 COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 8.0/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -61,10 +66,6 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION"
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/8.0/Dockerfile.fedora
+++ b/8.0/Dockerfile.fedora
@@ -57,6 +57,11 @@ COPY 8.0/root-common /
 COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 8.0/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -65,10 +70,6 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION"
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/8.0/Dockerfile.rhel7
+++ b/8.0/Dockerfile.rhel7
@@ -63,6 +63,11 @@ COPY 8.0/root-common /
 COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 8.0/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -71,10 +76,6 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions && \
     ${MYSQL_PREFIX}/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION"
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/8.0/Dockerfile.rhel8
+++ b/8.0/Dockerfile.rhel8
@@ -54,6 +54,11 @@ COPY 8.0/root-common /
 COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 8.0/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -62,10 +67,6 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION"
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -53,6 +53,11 @@ COPY 8.0/root-common /
 COPY 8.0/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 8.0/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -61,10 +66,6 @@ RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION"
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/s2i-common/bin/run
+++ b/s2i-common/bin/run
@@ -1,1 +1,0 @@
-/bin/run-mysqld


### PR DESCRIPTION
This pull request removes dead link from this upstream repository.

During the syncing source from upstream/GitLab repositories, the dead links are not sync bu
Testing Farm because security.
Therefore GitLab tests are failing because run script is missing.

Creating symlink in Dockerfile's solved this problem.

Similar pull requests are here: https://github.com/sclorg/postgresql-container/pull/552
https://github.com/sclorg/mariadb-container/pull/226
