### PR TITLE
deprecate c8s images, as EOL for c8s is 31th of May 2024

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,12 +20,7 @@ jobs:
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
             image_name: "mysql-80-c9s"
-          - dockerfile: "8.0/Dockerfile.c8s"
-            registry_namespace: "sclorg"
-            tag: "c8s"
-            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
-            image_name: "mysql-80-c8s"
+
           - dockerfile: "8.0/Dockerfile.fedora"
             registry_namespace: "fedora"
             tag: "80"

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "8.0" ]
-        os_test: [ "fedora", "rhel7", "rhel8", "rhel9", "c9s", "c8s"]
+        os_test: [ "fedora", "rhel7", "rhel8", "rhel9", "c9s" ]
         test_case: [ "container" ]
 
     if: |

--- a/8.0/root/usr/share/container-scripts/mysql/README.md
+++ b/8.0/root/usr/share/container-scripts/mysql/README.md
@@ -378,7 +378,6 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mysql-container.
 In that repository, the Dockerfile for CentOS is called Dockerfile, the Dockerfile
 for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
- the Dockerfile for RHEL9 is called Dockerfile.rhel9,
-the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ MySQL SQL Database Server Container Image
 
 Images available on Quay are:
 * CentOS 7 [mysql-80](https://quay.io/repository/centos7/mysql-80-centos7)
-* CentOS Stream 8 [mysql-80](https://quay.io/repository/sclorg/mysql-80-c8s)
 * CentOS Stream 9 [mysql-80](https://quay.io/repository/sclorg/mysql-80-c9s)
 * Fedora [mysql-80](https://quay.io/repository/fedora/mysql-80)
 
@@ -33,7 +32,6 @@ RHEL versions currently supported are:
 
 CentOS versions currently supported are:
 * CentOS7
-* CentOS Stream 8
 * CentOS Stream 9
 
 

--- a/imagestreams/mysql-centos.json
+++ b/imagestreams/mysql-centos.json
@@ -63,24 +63,6 @@
         }
       },
       {
-        "name": "8.0-el8",
-        "annotations": {
-          "openshift.io/display-name": "MySQL 8.0 (CentOS 8 Stream)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MySQL 8.0 database on CentOS 8 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
-          "iconClass": "icon-mysql-database",
-          "tags": "mysql",
-          "version": "8.0"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/sclorg/mysql-80-c8s:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "8.0-el7",
         "annotations": {
           "openshift.io/display-name": "MySQL 8.0 (CentOS 7)",


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
