### PR TITLE
Allow build and push MySQL-8.4 to quay.io/sclorg registry.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,6 +22,14 @@ jobs:
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
             image_name: "mysql-80-c9s"
 
+          - dockerfile: "8.4/Dockerfile.c10s"
+            docker_context: "8.4"
+            registry_namespace: "sclorg"
+            tag: "c10s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+            image_name: "mysql-84-c10s"
+
           - dockerfile: "8.0/Dockerfile.fedora"
             docker_context: "8.0"
             registry_namespace: "fedora"


### PR DESCRIPTION
Allow build and push MySQL-8.4 to quay.io/sclorg registry.

No MYSQL code is changed.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- issue-commentator = {"comment-id":"2383093722"} -->





























<!-- testing-farm = {"lock":"false","comment-id":"2383122134","data":[{"id":"29c1ec9d-e122-4083-a91a-6ba5369ae643","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":673.368771,"created":"2024-09-30T12:46:54.251881","updated":"2024-09-30T12:46:54.251887","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/29c1ec9d-e122-4083-a91a-6ba5369ae643\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/29c1ec9d-e122-4083-a91a-6ba5369ae643/pipeline.log\">pipeline</a>"]},{"id":"5b0eda1f-b778-4c29-ab93-6f5dd060fd2e","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":701.48364,"created":"2024-09-30T12:46:57.550448","updated":"2024-09-30T12:46:57.550455","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5b0eda1f-b778-4c29-ab93-6f5dd060fd2e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5b0eda1f-b778-4c29-ab93-6f5dd060fd2e/pipeline.log\">pipeline</a>"]},{"id":"03827c40-c16c-4568-b60c-9243044f89ab","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":787.567757,"created":"2024-09-30T12:46:54.624766","updated":"2024-09-30T12:46:54.624773","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/03827c40-c16c-4568-b60c-9243044f89ab\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/03827c40-c16c-4568-b60c-9243044f89ab/pipeline.log\">pipeline</a>"]},{"id":"f2c6a656-13a5-4686-94aa-748d85290dd5","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1508.060275,"created":"2024-09-30T12:46:54.570194","updated":"2024-09-30T12:46:54.570201","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2c6a656-13a5-4686-94aa-748d85290dd5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2c6a656-13a5-4686-94aa-748d85290dd5/pipeline.log\">pipeline</a>"]},{"id":"eb02983e-4ea2-4b05-8d01-25be9203ad51","name":"RHEL8 - 8.0","runTime":1794.503672,"created":"2024-09-30T12:46:54.415602","updated":"2024-09-30T12:46:54.415609","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb02983e-4ea2-4b05-8d01-25be9203ad51\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb02983e-4ea2-4b05-8d01-25be9203ad51/pipeline.log\">pipeline</a>"]}]} -->