### PR TITLE
Enable testing mysql-container on RHEL10 host

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "8.0", "8.4" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "8.0" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-pytest" ]
 
     steps:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "8.0" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
 
     steps:


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- issue-commentator = {"comment-id":"2616187185"} -->





























<!-- testing-farm = {"lock":"false","comment-id":"2616222866","data":[{"id":"1083adbd-f43a-406a-b2d3-535599be13f1","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":746.568202,"created":"2025-01-27T16:06:37.710413","updated":"2025-01-27T16:06:37.710421","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1083adbd-f43a-406a-b2d3-535599be13f1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1083adbd-f43a-406a-b2d3-535599be13f1/pipeline.log\">pipeline</a>"]},{"id":"36c2bc39-3e9e-4de1-8674-eae371598c1c","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":914.973116,"created":"2025-01-27T16:09:20.386392","updated":"2025-01-27T16:09:20.386405","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/36c2bc39-3e9e-4de1-8674-eae371598c1c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/36c2bc39-3e9e-4de1-8674-eae371598c1c/pipeline.log\">pipeline</a>"]},{"id":"1e2050b4-e896-47dd-ae28-abf547d082fc","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":1026.031316,"created":"2025-01-27T16:08:00.620442","updated":"2025-01-27T16:08:00.620452","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1e2050b4-e896-47dd-ae28-abf547d082fc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1e2050b4-e896-47dd-ae28-abf547d082fc/pipeline.log\">pipeline</a>"]},{"id":"7c5f2779-9a32-4bd5-af32-a95287789809","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1095.649253,"created":"2025-01-27T16:07:55.944748","updated":"2025-01-27T16:07:55.944757","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c5f2779-9a32-4bd5-af32-a95287789809\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c5f2779-9a32-4bd5-af32-a95287789809/pipeline.log\">pipeline</a>"]},{"id":"0ea6f219-84da-4147-a617-f3ef0b80d59c","name":"RHEL8 - 8.0","runTime":1221.724836,"created":"2025-01-27T16:06:51.329052","updated":"2025-01-27T16:06:51.329061","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ea6f219-84da-4147-a617-f3ef0b80d59c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ea6f219-84da-4147-a617-f3ef0b80d59c/pipeline.log\">pipeline</a>"]}]} -->