### PR TITLE
Support building mysql on RHEL10

### DIFF
--- a/8.4/Dockerfile.c10s
+++ b/8.4/Dockerfile.c10s
@@ -44,7 +44,7 @@ RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-ba
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/8.4/Dockerfile.c10s
+++ b/8.4/Dockerfile.c10s
@@ -40,7 +40,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server procps-ng" && \
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql$MYSQL_VERSION-server procps-ng" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \

--- a/8.4/Dockerfile.fedora
+++ b/8.4/Dockerfile.fedora
@@ -47,7 +47,7 @@ RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base community-mys
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/8.4/Dockerfile.rhel10
+++ b/8.4/Dockerfile.rhel10
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c9s:c9s
+FROM ubi10/s2i-core:latest
 
 # MySQL image for OpenShift.
 #
@@ -29,10 +29,10 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mysql$MYSQL_SHORT_VERSION,mysql-$MYSQL_SHORT_VERSION" \
       com.redhat.component="$NAME-$MYSQL_SHORT_VERSION-container" \
-      name="sclorg/$NAME-$MYSQL_SHORT_VERSION-c9s" \
+      name="rhel10/$NAME-$MYSQL_SHORT_VERSION" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/$NAME-$MYSQL_SHORT_VERSION-c9s:c9s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/$NAME-$MYSQL_SHORT_VERSION" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -40,8 +40,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mysql:$MYSQL_VERSION && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server procps-ng" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \

--- a/8.4/Dockerfile.rhel10
+++ b/8.4/Dockerfile.rhel10
@@ -40,7 +40,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server procps-ng" && \
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql$MYSQL_VERSION-server procps-ng" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \

--- a/8.4/Dockerfile.rhel9
+++ b/8.4/Dockerfile.rhel9
@@ -45,7 +45,7 @@ RUN yum -y module enable mysql:$MYSQL_VERSION && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/8.4/root/usr/share/container-scripts/mysql/README.md
+++ b/8.4/root/usr/share/container-scripts/mysql/README.md
@@ -360,6 +360,7 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mysql-container.
 In that repository, the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL 10 is called Dockerfile.rhel10,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Versions
 --------
 MySQL versions currently provided are:
 * [MySQL 8.0](8.0)
+* [MySQL 8.4](8.4)
 
 RHEL versions currently supported are:
 * RHEL8
 * RHEL9
+* RHEL10
 
 CentOS versions currently supported are:
 * CentOS Stream 9


### PR DESCRIPTION
This pull request adds support for building and testing mysql-container on RHEL10 host.

The pull request is separated into two commits:

* the first commit adds Dockerfile.rhel10 and fix `chown` to `mysql:root`
* The second commit updates main README.md file


<!-- issue-commentator = {"comment-id":"2618201597"} -->







































































<!-- testing-farm = {"lock":"false","comment-id":"2618436702","data":[{"id":"09bb2343-d2e7-4c9e-a831-e8dc9459c016","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1069.315824,"created":"2025-01-28T12:11:32.454922","updated":"2025-01-28T12:11:32.454930","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/09bb2343-d2e7-4c9e-a831-e8dc9459c016\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/09bb2343-d2e7-4c9e-a831-e8dc9459c016/pipeline.log\">pipeline</a>"]},{"id":"15b0543d-9637-44e3-9aee-17f116062dbe","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":627.194186,"created":"2025-01-28T12:11:36.100673","updated":"2025-01-28T12:11:36.100683","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/15b0543d-9637-44e3-9aee-17f116062dbe\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/15b0543d-9637-44e3-9aee-17f116062dbe/pipeline.log\">pipeline</a>"]},{"id":"ab02d0c1-b9ab-40e0-a06d-e33c0c9836c3","name":"RHEL8 - 8.0","runTime":1612.198906,"created":"2025-01-28T12:11:33.281424","updated":"2025-01-28T12:11:33.281432","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ab02d0c1-b9ab-40e0-a06d-e33c0c9836c3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ab02d0c1-b9ab-40e0-a06d-e33c0c9836c3/pipeline.log\">pipeline</a>"]},{"id":"6a5f98e1-16a6-48f3-8219-671a48f33d31","name":"RHEL10 - 8.4","status":"complete","outcome":"passed","runTime":1132.786403,"created":"2025-01-28T12:11:44.167462","updated":"2025-01-28T12:11:44.167470","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6a5f98e1-16a6-48f3-8219-671a48f33d31\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6a5f98e1-16a6-48f3-8219-671a48f33d31/pipeline.log\">pipeline</a>"]},{"id":"4baca258-c566-485b-95eb-5dfde60f57d3","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":693.188605,"created":"2025-01-28T12:11:35.250550","updated":"2025-01-28T12:11:35.250557","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4baca258-c566-485b-95eb-5dfde60f57d3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4baca258-c566-485b-95eb-5dfde60f57d3/pipeline.log\">pipeline</a>"]},{"id":"e4ed6b89-4c85-418e-8805-a3ad1376e815","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":793.875516,"created":"2025-01-28T12:11:32.340088","updated":"2025-01-28T12:11:32.340100","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e4ed6b89-4c85-418e-8805-a3ad1376e815\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e4ed6b89-4c85-418e-8805-a3ad1376e815/pipeline.log\">pipeline</a>"]}]} -->