### PR TITLE
Enable testing mysql 84 rhel9

### DIFF
--- a/8.4/Dockerfile.rhel9
+++ b/8.4/Dockerfile.rhel9
@@ -41,7 +41,7 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable mysql:$MYSQL_VERSION && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind9.18-utils groff-base mysql-server" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \

--- a/test/run
+++ b/test/run
@@ -19,7 +19,6 @@ run_general_tests
 run_change_password_test
 run_change_password_new_user_test
 run_replication_test
-run_doc_test
 run_s2i_test
 run_ssl_test
 run_datadir_actions_test

--- a/test/test_mysql_imagestream.py
+++ b/test/test_mysql_imagestream.py
@@ -24,7 +24,7 @@ TAG = TAGS.get(OS, None)
 class TestMySQLImagestreamTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="mysql", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="mysql", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_mysql_imagestream.py
+++ b/test/test_mysql_imagestream.py
@@ -37,8 +37,10 @@ class TestMySQLImagestreamTemplate:
         ]
     )
     def test_imagestream_template(self, template):
+        if VERSION == "8.4":
+            # It is not shipped yet
+            pytest.skip("Skipping test for 8.4")
         os_name = ''.join(i for i in OS if not i.isdigit())
-        print(os.getcwd())
         assert self.oc_api.deploy_image_stream_template(
             imagestream_file=f"imagestreams/mysql-{os_name}.json",
             template_file=f"examples/{template}",

--- a/test/test_mysql_imagestream_template.py
+++ b/test/test_mysql_imagestream_template.py
@@ -24,7 +24,7 @@ TAG = TAGS.get(OS, None)
 class TestMySQLImagestreamTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="mysql", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="mysql", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_mysql_imagestream_template.py
+++ b/test/test_mysql_imagestream_template.py
@@ -37,6 +37,9 @@ class TestMySQLImagestreamTemplate:
         ]
     )
     def test_imagestream_template(self, template):
+        if VERSION == "8.4":
+            # It is not shipped yet
+            pytest.skip("Skipping test for 8.4")
         os_name = ''.join(i for i in OS if not i.isdigit())
         assert self.oc_api.deploy_image_stream_template(
             imagestream_file=f"imagestreams/mysql-{os_name}.json",

--- a/test/test_mysql_local_template.py
+++ b/test/test_mysql_local_template.py
@@ -25,7 +25,7 @@ TAG = TAGS.get(OS, None)
 class TestMySQLDeployTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="mysql-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="mysql-testing", version=VERSION, shared_cluster=True)
         self.oc_api.import_is("imagestreams/mysql-rhel.json", "", skip_check=True)
 
     def teardown_method(self):

--- a/test/test_mysql_shared_helm_imagestreams.py
+++ b/test/test_mysql_shared_helm_imagestreams.py
@@ -13,7 +13,7 @@ class TestHelmRHELMySQLImageStreams:
     def setup_method(self):
         package_name = "redhat-mysql-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"


### PR DESCRIPTION
This pull request enables building and testing mysql-84

<!-- issue-commentator = {"comment-id":"2690749537"} -->























































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2690761910","data":[{"id":"2ac560db-e6f7-46d1-80af-1743c67bf1b4","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":730.819764,"created":"2025-03-04T12:00:49.915097","updated":"2025-03-04T12:00:49.915104","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2ac560db-e6f7-46d1-80af-1743c67bf1b4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2ac560db-e6f7-46d1-80af-1743c67bf1b4/pipeline.log\">pipeline</a>"]},{"id":"70ba01b2-2f54-427d-bd02-58ebcd94d226","name":"CentOS Stream 9 - 8.4","status":"complete","outcome":"passed","runTime":776.855959,"created":"2025-03-04T12:03:09.657739","updated":"2025-03-04T12:03:09.657745","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/70ba01b2-2f54-427d-bd02-58ebcd94d226\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/70ba01b2-2f54-427d-bd02-58ebcd94d226/pipeline.log\">pipeline</a>"]},{"id":"60d70a48-ded6-4b49-ae22-6cc60fe2125a","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":669.398388,"created":"2025-03-04T12:03:09.953405","updated":"2025-03-04T12:03:09.953411","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/60d70a48-ded6-4b49-ae22-6cc60fe2125a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/60d70a48-ded6-4b49-ae22-6cc60fe2125a/pipeline.log\">pipeline</a>"]},{"id":"30859911-1864-45de-a4b3-6bfdb0d09966","name":"RHEL9 - 8.4","status":"complete","outcome":"passed","runTime":1142.674659,"created":"2025-03-04T12:04:05.971067","updated":"2025-03-04T12:04:05.971073","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30859911-1864-45de-a4b3-6bfdb0d09966\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30859911-1864-45de-a4b3-6bfdb0d09966/pipeline.log\">pipeline</a>"]},{"id":"82347c63-bd9f-41a3-82bb-09850e4dc68d","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":734.993029,"created":"2025-03-04T12:02:51.777521","updated":"2025-03-04T12:02:51.777528","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/82347c63-bd9f-41a3-82bb-09850e4dc68d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/82347c63-bd9f-41a3-82bb-09850e4dc68d/pipeline.log\">pipeline</a>"]},{"id":"54eeacaa-bbbe-47e0-95f8-86a9c6260ec1","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1002.120142,"created":"2025-03-04T13:34:14.898004","updated":"2025-03-04T13:34:14.898012","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/54eeacaa-bbbe-47e0-95f8-86a9c6260ec1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/54eeacaa-bbbe-47e0-95f8-86a9c6260ec1/pipeline.log\">pipeline</a>"]},{"id":"5b916967-9eb4-463c-b6b1-cc4f2456fc87","name":"RHEL10 - 8.4","status":"complete","outcome":"passed","runTime":1067.546963,"created":"2025-03-04T13:35:27.168706","updated":"2025-03-04T13:35:27.168712","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b916967-9eb4-463c-b6b1-cc4f2456fc87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b916967-9eb4-463c-b6b1-cc4f2456fc87/pipeline.log\">pipeline</a>"]},{"id":"99390e65-9f28-4e1e-a9b6-7942cd7282c0","name":"RHEL8 - 8.0","runTime":1242.700829,"created":"2025-03-04T13:35:01.504876","updated":"2025-03-04T13:35:01.504882","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/99390e65-9f28-4e1e-a9b6-7942cd7282c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/99390e65-9f28-4e1e-a9b6-7942cd7282c0/pipeline.log\">pipeline</a>"]},{"id":"1643193d-4200-477b-8d12-1a3edea71a86","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1208.309407,"created":"2025-03-04T13:32:59.113838","updated":"2025-03-04T13:32:59.113844","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1643193d-4200-477b-8d12-1a3edea71a86\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1643193d-4200-477b-8d12-1a3edea71a86/pipeline.log\">pipeline</a>"]},{"id":"0714798b-bbab-4d23-af03-ebf8f8f39cae","name":"RHEL8 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1272.811993,"created":"2025-03-04T13:32:50.187170","updated":"2025-03-04T13:32:50.187176","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0714798b-bbab-4d23-af03-ebf8f8f39cae\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0714798b-bbab-4d23-af03-ebf8f8f39cae/pipeline.log\">pipeline</a>"]},{"id":"e22bc8ee-214c-4e13-8486-23d6467f9c93","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":3150.869655,"created":"2025-03-04T12:06:06.423340","updated":"2025-03-04T12:06:06.423346","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e22bc8ee-214c-4e13-8486-23d6467f9c93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e22bc8ee-214c-4e13-8486-23d6467f9c93/pipeline.log\">pipeline</a>"]},{"id":"ffe6af40-9a67-43e3-a028-63f7d2f47a49","name":"RHEL8 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1173.952126,"created":"2025-03-04T12:06:16.874916","updated":"2025-03-04T12:06:16.874922","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffe6af40-9a67-43e3-a028-63f7d2f47a49\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffe6af40-9a67-43e3-a028-63f7d2f47a49/pipeline.log\">pipeline</a>"]}]} -->