### PR TITLE
Update Dockerfile.rhel10 to support bind9.18-utils instead of bind-utils

### DIFF
--- a/8.4/Dockerfile.rhel10
+++ b/8.4/Dockerfile.rhel10
@@ -40,7 +40,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql$MYSQL_VERSION-server procps-ng" && \
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind9.18-utils groff-base mysql$MYSQL_VERSION-server procps-ng" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*' && \


### PR DESCRIPTION
This pull request modifies Dockerfile.rhel10 for 8.4 version so bind9.18-utils is used instead of bind-utils

<!-- issue-commentator = {"comment-id":"2740698156"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2740735406","data":[{"id":"8bbbb86e-8758-4b4b-ae6c-d4d1ea90a7e3","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":519.751105,"created":"2025-03-20T14:42:15.750937","updated":"2025-03-20T14:42:15.750944","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8bbbb86e-8758-4b4b-ae6c-d4d1ea90a7e3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8bbbb86e-8758-4b4b-ae6c-d4d1ea90a7e3/pipeline.log\">pipeline</a>"]},{"id":"781f4fc8-a366-41d0-9b7c-42243ed1b813","name":"CentOS Stream 9 - 8.4","status":"complete","outcome":"passed","runTime":575.797342,"created":"2025-03-20T14:42:20.283234","updated":"2025-03-20T14:42:20.283241","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/781f4fc8-a366-41d0-9b7c-42243ed1b813\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/781f4fc8-a366-41d0-9b7c-42243ed1b813/pipeline.log\">pipeline</a>"]},{"id":"6cc42df0-6824-4e2f-95df-4d3140a08fe9","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":559.808957,"created":"2025-03-20T14:42:20.333846","updated":"2025-03-20T14:42:20.333854","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6cc42df0-6824-4e2f-95df-4d3140a08fe9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6cc42df0-6824-4e2f-95df-4d3140a08fe9/pipeline.log\">pipeline</a>"]},{"id":"fec20548-1cc6-49ad-9faf-ab9555fdee9e","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":705.119673,"created":"2025-03-20T14:42:15.844731","updated":"2025-03-20T14:42:15.844738","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fec20548-1cc6-49ad-9faf-ab9555fdee9e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fec20548-1cc6-49ad-9faf-ab9555fdee9e/pipeline.log\">pipeline</a>"]},{"id":"0500f77f-2b1b-450e-b762-c3ed3780d180","name":"RHEL10 - 8.4","status":"complete","outcome":"error","runTime":1181.568907,"created":"2025-03-20T14:42:20.233490","updated":"2025-03-20T14:42:20.233499","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0500f77f-2b1b-450e-b762-c3ed3780d180\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0500f77f-2b1b-450e-b762-c3ed3780d180/pipeline.log\">pipeline</a>"]},{"id":"c67604d4-eb39-4b06-a3de-e01bbd662066","name":"RHEL8 - OpenShift 4 - 8.0","status":"complete","outcome":"error","runTime":1206.252626,"created":"2025-03-20T14:42:35.869382","updated":"2025-03-20T14:42:35.869390","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c67604d4-eb39-4b06-a3de-e01bbd662066\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c67604d4-eb39-4b06-a3de-e01bbd662066/pipeline.log\">pipeline</a>"]},{"id":"b9218abf-54fa-4ee2-a6bb-059e913cfc9b","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1468.785274,"created":"2025-03-20T14:42:20.223871","updated":"2025-03-20T14:42:20.223878","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9218abf-54fa-4ee2-a6bb-059e913cfc9b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9218abf-54fa-4ee2-a6bb-059e913cfc9b/pipeline.log\">pipeline</a>"]},{"id":"476f568a-a4d7-4c14-9b03-822b37335cbc","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1525.501658,"created":"2025-03-20T14:42:35.657948","updated":"2025-03-20T14:42:35.657956","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/476f568a-a4d7-4c14-9b03-822b37335cbc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/476f568a-a4d7-4c14-9b03-822b37335cbc/pipeline.log\">pipeline</a>"]},{"id":"75c6ead6-e370-4813-b3a5-a0a265e7e11f","name":"RHEL8 - 8.0","runTime":1787.873818,"created":"2025-03-20T14:42:21.416467","updated":"2025-03-20T14:42:21.416476","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/75c6ead6-e370-4813-b3a5-a0a265e7e11f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/75c6ead6-e370-4813-b3a5-a0a265e7e11f/pipeline.log\">pipeline</a>"]}]} -->