### PR TITLE
Rename bind-utils -> bind9.18-utils

### DIFF
--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -38,7 +38,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mysql-server" && \
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind9.18-utils groff-base mysql-server" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*' && \


### PR DESCRIPTION
Rename bind-utils -> bind9.18-utils
The package has been renamed for RHEL9

<!-- issue-commentator = {"comment-id":"2757062009"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2757084558","data":[{"id":"2674bc46-0c01-4a93-9541-5011d0b5680b","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":640.931152,"created":"2025-03-27T07:59:48.272779","updated":"2025-03-27T07:59:48.272785","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2674bc46-0c01-4a93-9541-5011d0b5680b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2674bc46-0c01-4a93-9541-5011d0b5680b/pipeline.log\">pipeline</a>"]},{"id":"36e84c52-3469-4f73-b4d1-8b0402a8d0a4","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":671.141842,"created":"2025-03-27T07:59:48.403995","updated":"2025-03-27T07:59:48.404001","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/36e84c52-3469-4f73-b4d1-8b0402a8d0a4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/36e84c52-3469-4f73-b4d1-8b0402a8d0a4/pipeline.log\">pipeline</a>"]},{"id":"55c25bc0-783d-438e-b8bf-94115789b1bc","name":"CentOS Stream 9 - 8.4","status":"complete","outcome":"passed","runTime":740.450141,"created":"2025-03-27T07:59:48.365413","updated":"2025-03-27T07:59:48.365420","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/55c25bc0-783d-438e-b8bf-94115789b1bc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/55c25bc0-783d-438e-b8bf-94115789b1bc/pipeline.log\">pipeline</a>"]},{"id":"d55ca823-7f2d-4fad-a3d9-9d7e7f349f2d","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":735.437716,"created":"2025-03-27T07:59:49.310106","updated":"2025-03-27T07:59:49.310136","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d55ca823-7f2d-4fad-a3d9-9d7e7f349f2d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d55ca823-7f2d-4fad-a3d9-9d7e7f349f2d/pipeline.log\">pipeline</a>"]},{"id":"37dbb2f7-4927-4985-a7fd-4330bb37a723","name":"RHEL10 - 8.4","status":"complete","outcome":"passed","runTime":1182.993216,"created":"2025-03-27T07:59:49.682837","updated":"2025-03-27T07:59:49.682843","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/37dbb2f7-4927-4985-a7fd-4330bb37a723\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/37dbb2f7-4927-4985-a7fd-4330bb37a723/pipeline.log\">pipeline</a>"]},{"id":"5fc4abbf-3715-46dd-9200-9872899c70a9","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1198.527455,"created":"2025-03-27T07:59:50.072964","updated":"2025-03-27T07:59:50.072970","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5fc4abbf-3715-46dd-9200-9872899c70a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5fc4abbf-3715-46dd-9200-9872899c70a9/pipeline.log\">pipeline</a>"]},{"id":"d4c8b97c-300e-4d66-a8d9-8adacdf7655c","name":"RHEL9 - 8.4","status":"complete","outcome":"passed","runTime":1310.109189,"created":"2025-03-27T07:59:50.073420","updated":"2025-03-27T07:59:50.073427","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4c8b97c-300e-4d66-a8d9-8adacdf7655c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4c8b97c-300e-4d66-a8d9-8adacdf7655c/pipeline.log\">pipeline</a>"]},{"id":"0adadf4d-6887-48cb-a183-af56b06f3ff6","name":"RHEL8 - 8.0","status":"complete","outcome":"passed","runTime":1458.064213,"created":"2025-03-27T07:59:48.057980","updated":"2025-03-27T07:59:48.057987","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0adadf4d-6887-48cb-a183-af56b06f3ff6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0adadf4d-6887-48cb-a183-af56b06f3ff6/pipeline.log\">pipeline</a>"]},{"id":"87725bc6-f00c-451d-9533-b6e661927f76","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1024.883205,"created":"2025-03-27T08:22:06.632252","updated":"2025-03-27T08:22:06.632259","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87725bc6-f00c-451d-9533-b6e661927f76\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87725bc6-f00c-451d-9533-b6e661927f76/pipeline.log\">pipeline</a>"]},{"id":"ddb7e49b-2fb1-483d-9545-aedb30fcfa9b","name":"RHEL8 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1207.063034,"created":"2025-03-27T08:22:07.320646","updated":"2025-03-27T08:22:07.320654","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ddb7e49b-2fb1-483d-9545-aedb30fcfa9b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ddb7e49b-2fb1-483d-9545-aedb30fcfa9b/pipeline.log\">pipeline</a>"]},{"id":"279e378f-c617-4d94-bbfc-40cf21184b41","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":2871.519206,"created":"2025-03-27T08:22:16.322424","updated":"2025-03-27T08:22:16.322432","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/279e378f-c617-4d94-bbfc-40cf21184b41\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/279e378f-c617-4d94-bbfc-40cf21184b41/pipeline.log\">pipeline</a>"]},{"id":"e63d6fcc-2f29-45bd-96c3-ac8c5fea19b3","name":"RHEL8 - PyTest - OpenShift 4 - 8.0","runTime":2952.291235,"created":"2025-03-27T08:22:15.657793","updated":"2025-03-27T08:22:15.657800","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e63d6fcc-2f29-45bd-96c3-ac8c5fea19b3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e63d6fcc-2f29-45bd-96c3-ac8c5fea19b3/pipeline.log\">pipeline</a>"]}]} -->