### PR TITLE
[revert] Revert using bash parameter substitution, 'bash' is not guaranteed

### DIFF
--- a/8.0/Dockerfile.c9s
+++ b/8.0/Dockerfile.c9s
@@ -10,10 +10,8 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.0
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.0 \
+    MYSQL_SHORT_VERSION=80 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql

--- a/8.0/Dockerfile.fedora
+++ b/8.0/Dockerfile.fedora
@@ -10,10 +10,8 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.0
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.0 \
+    MYSQL_SHORT_VERSION=80 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql

--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -10,10 +10,8 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.0
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.0 \
+    MYSQL_SHORT_VERSION=80 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql

--- a/8.4/Dockerfile.c10s
+++ b/8.4/Dockerfile.c10s
@@ -10,10 +10,8 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.4
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.4 \
+    MYSQL_SHORT_VERSION=84 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql

--- a/8.4/Dockerfile.c9s
+++ b/8.4/Dockerfile.c9s
@@ -10,10 +10,8 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.4
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.4 \
+    MYSQL_SHORT_VERSION=84 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql

--- a/8.4/Dockerfile.fedora
+++ b/8.4/Dockerfile.fedora
@@ -10,10 +10,8 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.4
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.4 \
+    MYSQL_SHORT_VERSION=84 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql

--- a/8.4/Dockerfile.rhel10
+++ b/8.4/Dockerfile.rhel10
@@ -10,10 +10,8 @@ FROM ubi10/s2i-core:latest
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.4
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.4 \
+    MYSQL_SHORT_VERSION=84 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql

--- a/8.4/Dockerfile.rhel9
+++ b/8.4/Dockerfile.rhel9
@@ -10,10 +10,8 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=8.4
-
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+ENV MYSQL_VERSION=8.4 \
+    MYSQL_SHORT_VERSION=84 \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mysql


### PR DESCRIPTION
Build system without bash fails with:
 | Error: resolving step {Value:env Next:0xc0001524d0 Children:[]
 | Attributes:map[] Original:ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./}
 | VERSION=${MYSQL_VERSION}     APP_DATA=/opt/app-root/src     HOME=/var/lib/mysql
 | NAME=mariadb     SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server"
 | DESCRIPTION="..."
 | Flags:[] StartLine:16 EndLine:25}: Missing ':' in substitution: ${MYSQL_VERSION//./}

I tried a lot of ways to work around this, none worked.

Using subshells
 - ENV does not support white characters on the right side of assignment Using subshells with scrambled whitepsace characters
 - ENV won't invoke the subshell, will treat right side of the assignement as a simple text Using RUN to set $SHELL, trying to use 'export'
 - won't be preserved between layers using SHELL directive
 - Docker specific

Fedora only knows '/bin/bash' and 'sh' is just a symbolic link to '/bin/bash'. So the 'sh' unable to do the parameter expansions must come from the build host.

My guess would be that setting 'shell: bash' here:
  https://github.com/sclorg/build-and-push-action/blob/main/action.yml#L115
might help.

However this seems to be impossible to force inside of the containerfile itself, so I'm reverting the bash parameter substitution code entirely.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"2886616305"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2886638174","data":[{"id":"f523d614-3b34-40ae-b7ae-4150129047e6","name":"CentOS Stream 9 - 8.4","status":"complete","outcome":"passed","runTime":544.162989,"created":"2025-05-16T12:42:40.276003","updated":"2025-05-16T12:42:40.276009","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f523d614-3b34-40ae-b7ae-4150129047e6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f523d614-3b34-40ae-b7ae-4150129047e6/pipeline.log\">pipeline</a>"]},{"id":"5af1eb36-d04a-4f75-8c48-f18956cb62b4","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":547.375486,"created":"2025-05-16T12:42:40.308414","updated":"2025-05-16T12:42:40.308419","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5af1eb36-d04a-4f75-8c48-f18956cb62b4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5af1eb36-d04a-4f75-8c48-f18956cb62b4/pipeline.log\">pipeline</a>"]},{"id":"b754820b-a13b-418e-b37e-2ff7fe79bbdd","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":611.42657,"created":"2025-05-16T12:42:40.022703","updated":"2025-05-16T12:42:40.022709","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b754820b-a13b-418e-b37e-2ff7fe79bbdd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b754820b-a13b-418e-b37e-2ff7fe79bbdd/pipeline.log\">pipeline</a>"]},{"id":"dde01dd0-ceaf-47bb-be8f-5d4b35a97607","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":666.089137,"created":"2025-05-16T12:42:40.173812","updated":"2025-05-16T12:42:40.173821","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/dde01dd0-ceaf-47bb-be8f-5d4b35a97607\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/dde01dd0-ceaf-47bb-be8f-5d4b35a97607/pipeline.log\">pipeline</a>"]},{"id":"ff811630-70da-4ab1-8615-f0af0d2cf31c","name":"Fedora - 8.4","status":"complete","outcome":"passed","runTime":688.229418,"created":"2025-05-16T12:42:41.252761","updated":"2025-05-16T12:42:41.252767","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ff811630-70da-4ab1-8615-f0af0d2cf31c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ff811630-70da-4ab1-8615-f0af0d2cf31c/pipeline.log\">pipeline</a>"]},{"id":"afe15165-b052-419e-8887-dfde75a8a268","name":"RHEL10 - 8.4","status":"complete","outcome":"passed","runTime":1116.941353,"created":"2025-05-16T12:42:40.426895","updated":"2025-05-16T12:42:40.426902","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/afe15165-b052-419e-8887-dfde75a8a268\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/afe15165-b052-419e-8887-dfde75a8a268/pipeline.log\">pipeline</a>"]},{"id":"b97ee525-e336-4178-bf5b-e4de209ed02e","name":"RHEL8 - 8.0","status":"complete","outcome":"passed","runTime":1220.890497,"created":"2025-05-16T12:42:40.438881","updated":"2025-05-16T12:42:40.438886","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b97ee525-e336-4178-bf5b-e4de209ed02e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b97ee525-e336-4178-bf5b-e4de209ed02e/pipeline.log\">pipeline</a>"]},{"id":"a7229b19-522a-428c-bed0-ef2d5341880b","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1266.741233,"created":"2025-05-16T12:42:39.370077","updated":"2025-05-16T12:42:39.370083","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7229b19-522a-428c-bed0-ef2d5341880b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7229b19-522a-428c-bed0-ef2d5341880b/pipeline.log\">pipeline</a>"]},{"id":"b4639780-2349-4813-b06c-97b339a55be5","name":"RHEL9 - 8.4","runTime":1429.336586,"created":"2025-05-16T12:42:39.322144","updated":"2025-05-16T12:42:39.322154","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4639780-2349-4813-b06c-97b339a55be5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4639780-2349-4813-b06c-97b339a55be5/pipeline.log\">pipeline</a>"]}]} -->