### PR TITLE
[bugfix] The version must be set in a separate stage, so it can be reused in the other calls

### DIFF
--- a/8.0/Dockerfile.c9s
+++ b/8.0/Dockerfile.c9s
@@ -10,13 +10,14 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.0 \
-    MYSQL_SHORT_VERSION=80 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=80
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \

--- a/8.0/Dockerfile.fedora
+++ b/8.0/Dockerfile.fedora
@@ -10,13 +10,14 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.0 \
-    MYSQL_SHORT_VERSION=80 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=80
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \

--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -10,13 +10,14 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.0 \
-    MYSQL_SHORT_VERSION=80 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=80
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \

--- a/8.4/Dockerfile.c10s
+++ b/8.4/Dockerfile.c10s
@@ -10,13 +10,14 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.4 \
-    MYSQL_SHORT_VERSION=84 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=84
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \

--- a/8.4/Dockerfile.c9s
+++ b/8.4/Dockerfile.c9s
@@ -10,13 +10,14 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.4 \
-    MYSQL_SHORT_VERSION=84 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=84
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \

--- a/8.4/Dockerfile.fedora
+++ b/8.4/Dockerfile.fedora
@@ -10,13 +10,14 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.4 \
-    MYSQL_SHORT_VERSION=84 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=84
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \

--- a/8.4/Dockerfile.rhel10
+++ b/8.4/Dockerfile.rhel10
@@ -10,13 +10,14 @@ FROM ubi10/s2i-core:latest
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.4 \
-    MYSQL_SHORT_VERSION=84 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=84
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \

--- a/8.4/Dockerfile.rhel9
+++ b/8.4/Dockerfile.rhel9
@@ -10,13 +10,14 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=8.4 \
-    MYSQL_SHORT_VERSION=84 \
-    APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql \
-    NAME=mysql
+    MYSQL_SHORT_VERSION=84
 
-ENV SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
+ENV APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mysql \
+    SUMMARY="MySQL ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MySQL is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MySQL mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \


### PR DESCRIPTION
otherwise it's not available when the rest of the ENV block is processed and the ENV values relying on this variable are malformed.

This commit was mistakenly reverted as a part of revert of a different change



<!-- issue-commentator = {"comment-id":"2901024391"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2900839145","data":[{"id":"66ed7d5a-ec52-4e68-b458-5b0590ababfa","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":778.118981,"created":"2025-05-23T07:18:43.338050","updated":"2025-05-23T07:18:43.338056","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/66ed7d5a-ec52-4e68-b458-5b0590ababfa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/66ed7d5a-ec52-4e68-b458-5b0590ababfa/pipeline.log\">pipeline</a>"]},{"id":"8dc196ac-7b6b-430e-b7ce-db4667777636","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":595.64397,"created":"2025-05-23T07:18:38.258135","updated":"2025-05-23T07:18:38.258142","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8dc196ac-7b6b-430e-b7ce-db4667777636\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8dc196ac-7b6b-430e-b7ce-db4667777636/pipeline.log\">pipeline</a>"]},{"id":"2b64282f-7a92-4e7f-a57d-567def6e18de","name":"Fedora - 8.4","status":"complete","outcome":"passed","runTime":774.873935,"created":"2025-05-23T07:18:44.678694","updated":"2025-05-23T07:18:44.678699","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2b64282f-7a92-4e7f-a57d-567def6e18de\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2b64282f-7a92-4e7f-a57d-567def6e18de/pipeline.log\">pipeline</a>"]},{"id":"241f64c9-297c-4b64-8e4a-aa4d72b85a09","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":536.661007,"created":"2025-05-23T07:18:36.002693","updated":"2025-05-23T07:18:36.002700","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/241f64c9-297c-4b64-8e4a-aa4d72b85a09\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/241f64c9-297c-4b64-8e4a-aa4d72b85a09/pipeline.log\">pipeline</a>"]},{"id":"a199c9aa-5aee-4c50-b293-f4dccc2a089f","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1129.270224,"created":"2025-05-23T07:18:37.335050","updated":"2025-05-23T07:18:37.335055","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a199c9aa-5aee-4c50-b293-f4dccc2a089f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a199c9aa-5aee-4c50-b293-f4dccc2a089f/pipeline.log\">pipeline</a>"]},{"id":"f653488f-8a4f-4326-a549-52099407920a","name":"RHEL9 - 8.4","runTime":1203.88221,"created":"2025-05-23T07:18:37.284587","updated":"2025-05-23T07:18:37.284593","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f653488f-8a4f-4326-a549-52099407920a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f653488f-8a4f-4326-a549-52099407920a/pipeline.log\">pipeline</a>"]},{"id":"70668d55-7f6e-4f32-ad6a-86670a5b16f7","name":"RHEL8 - 8.0","status":"complete","outcome":"passed","runTime":1110.147612,"created":"2025-05-23T07:18:36.347577","updated":"2025-05-23T07:18:36.347583","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/70668d55-7f6e-4f32-ad6a-86670a5b16f7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/70668d55-7f6e-4f32-ad6a-86670a5b16f7/pipeline.log\">pipeline</a>"]},{"id":"fd86c0c1-3458-4e9c-840e-1a3d0e6bca4b","name":"CentOS Stream 9 - 8.4","status":"complete","outcome":"passed","runTime":551.328362,"created":"2025-05-23T07:18:38.428242","updated":"2025-05-23T07:18:38.428249","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fd86c0c1-3458-4e9c-840e-1a3d0e6bca4b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fd86c0c1-3458-4e9c-840e-1a3d0e6bca4b/pipeline.log\">pipeline</a>"]},{"id":"a38ca661-3003-4af5-8bf6-efb7cc6d37cd","name":"RHEL10 - 8.4","status":"complete","outcome":"passed","runTime":977.801732,"created":"2025-05-23T07:18:35.969206","updated":"2025-05-23T07:18:35.969214","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a38ca661-3003-4af5-8bf6-efb7cc6d37cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a38ca661-3003-4af5-8bf6-efb7cc6d37cd/pipeline.log\">pipeline</a>"]}]} -->