### PR TITLE
Enable building of MySQL 8.4 image for Fedora in the 'build-and-push.yaml'

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -45,6 +45,15 @@ jobs:
             quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
             image_name: "mysql-80"
+
+          - dockerfile: "8.4/Dockerfile.fedora"
+            docker_context: "8.4"
+            registry_namespace: "fedora"
+            tag: "84"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            image_name: "mysql-84"
+
     steps:
       - name: Build and push to quay.io registry
         uses: sclorg/build-and-push-action@v4


### PR DESCRIPTION
The:
  https://quay.io/repository/fedora/mysql-84?tab=info
 is empty

<!-- issue-commentator = {"comment-id":"3150629059"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3150688698","data":[{"id":"358f4c2e-0d14-44c6-a482-eda6fe9cae67","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":586.296157,"created":"2025-08-05T07:54:01.140789","updated":"2025-08-05T07:54:01.140795","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/358f4c2e-0d14-44c6-a482-eda6fe9cae67\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/358f4c2e-0d14-44c6-a482-eda6fe9cae67/pipeline.log\">pipeline</a>"]},{"id":"46a14ff5-a21d-4c83-b6c6-78f4942ddb26","name":"CentOS Stream 9 - 8.4","status":"complete","outcome":"passed","runTime":531.550624,"created":"2025-08-05T08:08:50.606351","updated":"2025-08-05T08:08:50.606357","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/46a14ff5-a21d-4c83-b6c6-78f4942ddb26\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/46a14ff5-a21d-4c83-b6c6-78f4942ddb26/pipeline.log\">pipeline</a>"]},{"id":"156a7846-008b-44b9-9631-103e4665762e","name":"RHEL10 - 8.4","runTime":1050.342444,"created":"2025-08-05T08:08:26.234410","updated":"2025-08-05T08:08:26.234419","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/156a7846-008b-44b9-9631-103e4665762e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/156a7846-008b-44b9-9631-103e4665762e/pipeline.log\">pipeline</a>"]},{"id":"2953290e-fd87-4dad-886e-8a36d276a2e0","name":"RHEL9 - 8.4","status":"complete","outcome":"passed","runTime":1476.333166,"created":"2025-08-05T07:50:07.555312","updated":"2025-08-05T07:50:07.555321","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2953290e-fd87-4dad-886e-8a36d276a2e0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2953290e-fd87-4dad-886e-8a36d276a2e0/pipeline.log\">pipeline</a>"]},{"id":"d65da9d2-994f-4470-bfec-49bddceb6ad8","name":"RHEL8 - 8.0","status":"complete","outcome":"passed","runTime":1271.679783,"created":"2025-08-05T07:35:32.026399","updated":"2025-08-05T07:35:32.026404","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d65da9d2-994f-4470-bfec-49bddceb6ad8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d65da9d2-994f-4470-bfec-49bddceb6ad8/pipeline.log\">pipeline</a>"]},{"id":"1ea7beeb-70de-4f98-9314-4d14034ea3f2","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1275.284904,"created":"2025-08-05T08:01:19.078338","updated":"2025-08-05T08:01:19.078344","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ea7beeb-70de-4f98-9314-4d14034ea3f2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ea7beeb-70de-4f98-9314-4d14034ea3f2/pipeline.log\">pipeline</a>"]},{"id":"70138cdc-6112-42ae-8ad5-41b69b29b7e4","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":738.372877,"created":"2025-08-05T07:55:33.220750","updated":"2025-08-05T07:55:33.220758","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/70138cdc-6112-42ae-8ad5-41b69b29b7e4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/70138cdc-6112-42ae-8ad5-41b69b29b7e4/pipeline.log\">pipeline</a>"]},{"id":"b33377ed-ce1f-4f4f-8d16-3fec28eaa594","name":"Fedora - 8.4","status":"complete","outcome":"passed","runTime":675.338985,"created":"2025-08-05T07:56:36.416591","updated":"2025-08-05T07:56:36.416597","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b33377ed-ce1f-4f4f-8d16-3fec28eaa594\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b33377ed-ce1f-4f4f-8d16-3fec28eaa594/pipeline.log\">pipeline</a>"]},{"id":"84e11de0-14a4-4a07-a2af-3db96d32816c","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":552.22998,"created":"2025-08-05T08:08:07.782855","updated":"2025-08-05T08:08:07.782862","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/84e11de0-14a4-4a07-a2af-3db96d32816c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/84e11de0-14a4-4a07-a2af-3db96d32816c/pipeline.log\">pipeline</a>"]}]} -->