### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/8.4/Dockerfile.rhel10
+++ b/8.4/Dockerfile.rhel10
@@ -31,7 +31,6 @@ LABEL summary="${SUMMARY}" \
       io.openshift.tags="database,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279206373"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279324735","data":[{"id":"69f3d137-93a3-468a-8a56-08247aa55d10","name":"Fedora - 8.4","status":"complete","outcome":"passed","runTime":620.170013,"created":"2025-09-11T08:49:22.575073","updated":"2025-09-11T08:49:22.575080","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/69f3d137-93a3-468a-8a56-08247aa55d10\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/69f3d137-93a3-468a-8a56-08247aa55d10/pipeline.log\">pipeline</a>"]},{"id":"bc6d017b-e491-4ba1-b080-9c54e6b02b19","name":"CentOS Stream 9 - 8.0","status":"complete","outcome":"passed","runTime":720.300803,"created":"2025-09-11T08:49:43.690476","updated":"2025-09-11T08:49:43.690483","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bc6d017b-e491-4ba1-b080-9c54e6b02b19\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bc6d017b-e491-4ba1-b080-9c54e6b02b19/pipeline.log\">pipeline</a>"]},{"id":"be4331a7-ae37-41d5-a479-303c9798b4aa","name":"CentOS Stream 10 - 8.4","status":"complete","outcome":"passed","runTime":684.214276,"created":"2025-09-11T08:51:54.328404","updated":"2025-09-11T08:51:54.328410","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/be4331a7-ae37-41d5-a479-303c9798b4aa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/be4331a7-ae37-41d5-a479-303c9798b4aa/pipeline.log\">pipeline</a>"]},{"id":"51256e7b-e1a5-4f92-9b73-061c7dd9b89f","name":"RHEL10 - 8.4","status":"complete","outcome":"passed","runTime":1040.435255,"created":"2025-09-11T08:46:33.652309","updated":"2025-09-11T08:46:33.652315","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/51256e7b-e1a5-4f92-9b73-061c7dd9b89f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/51256e7b-e1a5-4f92-9b73-061c7dd9b89f/pipeline.log\">pipeline</a>"]},{"id":"6d1d96c8-7e96-4a09-a248-5af9ba971ca5","name":"Fedora - 8.0","status":"complete","outcome":"passed","runTime":580.543739,"created":"2025-09-11T08:54:36.505836","updated":"2025-09-11T08:54:36.505843","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6d1d96c8-7e96-4a09-a248-5af9ba971ca5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6d1d96c8-7e96-4a09-a248-5af9ba971ca5/pipeline.log\">pipeline</a>"]},{"id":"df28a657-5be9-4743-b4f3-189f5c43de14","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1328.012229,"created":"2025-09-11T08:46:05.282573","updated":"2025-09-11T08:46:05.282580","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/df28a657-5be9-4743-b4f3-189f5c43de14\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/df28a657-5be9-4743-b4f3-189f5c43de14/pipeline.log\">pipeline</a>"]},{"id":"856b2f02-3a32-4ad2-93f1-4aed4597753f","name":"CentOS Stream 9 - 8.4","status":"complete","outcome":"passed","runTime":814.589695,"created":"2025-09-11T08:56:12.547857","updated":"2025-09-11T08:56:12.547866","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/856b2f02-3a32-4ad2-93f1-4aed4597753f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/856b2f02-3a32-4ad2-93f1-4aed4597753f/pipeline.log\">pipeline</a>"]},{"id":"3269aceb-d6ab-483b-96d3-33aba29cb597","name":"RHEL8 - 8.0","status":"complete","outcome":"passed","runTime":1153.065322,"created":"2025-09-11T08:50:27.815019","updated":"2025-09-11T08:50:27.815026","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3269aceb-d6ab-483b-96d3-33aba29cb597\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3269aceb-d6ab-483b-96d3-33aba29cb597/pipeline.log\">pipeline</a>"]},{"id":"d0e7055d-1ed5-4db9-8c80-34db8d7584c4","name":"RHEL9 - 8.4","runTime":1377.490752,"created":"2025-09-11T08:46:31.042630","updated":"2025-09-11T08:46:31.042639","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0e7055d-1ed5-4db9-8c80-34db8d7584c4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0e7055d-1ed5-4db9-8c80-34db8d7584c4/pipeline.log\">pipeline</a>"]}]} -->