### PR TITLE
OKD-380: Add missing namespace to image trigger annotations

### DIFF
--- a/examples/mysql-ephemeral-template.json
+++ b/examples/mysql-ephemeral-template.json
@@ -75,7 +75,7 @@
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {

--- a/examples/mysql-persistent-template.json
+++ b/examples/mysql-persistent-template.json
@@ -45,8 +45,7 @@
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
-          "template.openshift.io/expose-uri": "mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\"mysql\")].port}",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "template.openshift.io/expose-uri": "mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\"mysql\")].port}"
         }
       },
       "spec": {
@@ -85,7 +84,7 @@
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {


### PR DESCRIPTION
## Problem

Deploying MySQL from the OKD 4.22 Software Catalog fails with:

```
spec.containers[0].image: Invalid value: " ": must not have leading or trailing whitespace
```

Reported in https://github.com/okd-project/okd/issues/2337

## Root Cause

When templates were migrated from `DeploymentConfig` to `Deployment`, the `image.openshift.io/triggers` annotation dropped the `namespace` field from the `ImageStreamTag` reference. Without it, the image trigger controller defaults to the Deployment's own namespace instead of `openshift`, so it can't find the ImageStream and the container image is never resolved.

## Fix

- Add `"namespace":"${NAMESPACE}"` to the trigger annotation's `from` object in both `mysql-persistent` and `mysql-ephemeral` templates
- Remove a stray `image.openshift.io/triggers` annotation from the Service object in `mysql-persistent-template.json` — it was a copy-paste error that referenced `${MARIADB_VERSION}` (Services don't have containers, so this annotation had no effect)

## Impact

These template files are the upstream source for `openshift/library` (via `make import`) and ultimately `openshift/cluster-samples-operator`. An immediate fix was applied directly to the operator in [openshift/cluster-samples-operator#701](https://github.com/openshift/cluster-samples-operator/pull/701). This upstream fix ensures the bug doesn't recur on the next sync.

<!-- issue-commentator = {"comment-id":"4775554108"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example MySQL deployment templates (ephemeral and persistent) to explicitly reference image streams with namespace parameters, ensuring proper deployment triggers across different environments.
  * Removed redundant image stream annotation from the Service resource in the persistent template to streamline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->